### PR TITLE
Replace `AttributedStringMarkdownParser.PatternOptions` with `AttributedStringMarkdownParser.SyntaxExtension`

### DIFF
--- a/Examples/TextualDemo/TextualDemo/TableDemo.swift
+++ b/Examples/TextualDemo/TextualDemo/TableDemo.swift
@@ -71,7 +71,7 @@ struct TableDemo: View {
         }
         StructuredText(
           markdown: overflowContent,
-          patternOptions: .init(emoji: .mastoEmoji)
+          syntaxExtensions: [.emoji(.mastoEmoji)]
         )
       } header: {
         Text("Overflow Style")


### PR DESCRIPTION
- Introduce `AttributedStringMarkdownParser.SyntaxExtension` to replace internal pattern rules with public syntax extensions (`emoji`/`math` helpers included).
- Deprecate `AttributedStringMarkdownParser.PatternOptions` and related initializers, migrating call sites and tests to `syntaxExtensions`.
- Update inline docs and README examples to reflect the new API.