### PR TITLE
Clear text selection on tap outside on iOS

### DIFF
--- a/Sources/Textual/Internal/TextInteraction/UIKit/UITextInteractionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/UIKit/UITextInteractionView.swift
@@ -110,6 +110,7 @@
     @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
       let location = gesture.location(in: self)
       guard let url = model.url(for: location) else {
+        model.selectedRange = nil
         return
       }
       openURL(url)


### PR DESCRIPTION
## Problem

On iOS, when a user selects text in a `StructuredText` block and then taps elsewhere (on a non-URL area), the selection persists indefinitely. The only way to dismiss it is to select text in a different block (which triggers the `TextSelectionCoordinator`).

## Root Cause

The macOS `NSTextInteractionView.mouseDown` handler already clears selection correctly:

```swift
case 1:
    if let url = model.url(for: location) {
        openURL(url)
    } else {
        resetSelection()  // ✅ Clears selection
    }
```

But the iOS `UITextInteractionView.handleTap` was missing equivalent behavior — it only opens URLs and returns early otherwise, leaving the selection untouched:

```swift
@objc private func handleTap(_ gesture: UITapGestureRecognizer) {
    let location = gesture.location(in: self)
    guard let url = model.url(for: location) else {
        return  // ❌ Selection persists
    }
    openURL(url)
}
```

## Fix

Set `model.selectedRange = nil` when a tap lands on a non-URL area, matching the macOS behavior:

```swift
guard let url = model.url(for: location) else {
    model.selectedRange = nil  // Clear selection, matching macOS
    return
}
```

One-line change. Brings iOS in line with macOS.