### PR TITLE
Add support for custom text run effects with `TextRunEffect` protocol

### DIFF
--- a/Sources/Textual/Internal/Helpers/AttributedString.swift
+++ b/Sources/Textual/Internal/Helpers/AttributedString.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 extension AttributedStringProtocol {
+  /// Returns `true` if any run contains a `TextRunEffect` attribute.
+  var hasTextEffect: Bool {
+    runs.contains { $0.textualEffect != nil }
+  }
+
   var isMathBlock: Bool {
     let attachments = self.attachments()
 

--- a/Sources/Textual/Internal/TextFragment/TextBuilder.swift
+++ b/Sources/Textual/Internal/TextFragment/TextBuilder.swift
@@ -93,6 +93,16 @@ extension Text {
         text = text.customAttribute(LinkAttribute(link))
       }
 
+      // Add effect attribute for TextualTextRenderer
+      if let effect = run.textualEffect {
+        // Check if this is an animatable effect marker
+        if let markerID = effect.animatableEffectMarkerID {
+          text = text.customAttribute(AnimatableEffectMarkerAttribute(effectTypeID: markerID))
+        } else {
+          text = text.customAttribute(TextEffectAttribute(effect: effect))
+        }
+      }
+
       return text
     }
 

--- a/Sources/Textual/Internal/TextRenderer/AnimatableEffect.swift
+++ b/Sources/Textual/Internal/TextRenderer/AnimatableEffect.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+// MARK: - Overview
+//
+// This file provides SwiftUI animation support for text effects through
+// `AnimatableEffectMarker` and `AnimatableEffectModifier`.
+//
+// The key insight is that effects stored in AttributeContainer cannot participate
+// in SwiftUI's animation system due to type erasure. This is solved by:
+//
+// 1. Using `AnimatableEffectMarker<Effect>` as a placeholder in InlineStyle
+// 2. Passing the actual effect through the environment via `.textual.animatableEffect()`
+// 3. Having `TextFragment` read the effect and pass it to `TextualTextRenderer`
+//
+// The `AnimatableEffectModifier` conforms to `Animatable`, enabling SwiftUI to
+// interpolate the effect's `animatableData` during animations.
+
+// MARK: - Environment Key for Animatable Effects
+
+extension EnvironmentValues {
+  @Entry var animatableEffect: AnyAnimatableEffect? = nil
+}
+
+// MARK: - Type-Erased Animatable Effect
+
+/// A type-erased wrapper for animatable effects that can be stored in environment.
+struct AnyAnimatableEffect {
+  private let _markerID: String
+  private let _draw: (Text.Layout.Run, inout GraphicsContext) -> Void
+
+  init<Effect: TextRunEffect>(_ effect: Effect) {
+    self._markerID = AnimatableEffectMarker<Effect>.markerID
+    self._draw = { run, context in
+      effect.draw(run: run, in: &context)
+    }
+  }
+
+  var markerID: String { _markerID }
+
+  func draw(run: Text.Layout.Run, in context: inout GraphicsContext) {
+    _draw(run, &context)
+  }
+}
+
+// MARK: - Animatable Effect Marker
+
+/// A marker attribute that indicates a run should use an animatable effect.
+struct AnimatableEffectMarkerAttribute: TextAttribute {
+  let effectTypeID: String
+}
+
+/// A marker effect that indicates a run should use an animatable effect.
+///
+/// Use this as a placeholder in `InlineStyle` when you want to animate
+/// the actual effect through the `.textual.animatableEffect()` modifier.
+///
+/// ```swift
+/// InlineText(markdown: "**Bold text**")
+///   .textual.inlineStyle(
+///     InlineStyle().strong(EffectProperty(AnimatableEffectMarker<HighlightEffect>()))
+///   )
+///   .textual.animatableEffect(HighlightEffect(progress: progress))
+/// ```
+public struct AnimatableEffectMarker<Effect: TextRunEffect>: TextRunEffect {
+  static var markerID: String {
+    String(reflecting: Effect.self)
+  }
+
+  public init() {}
+
+  public func draw(run: Text.Layout.Run, in context: inout GraphicsContext) {
+    // No-op - the actual drawing is done by TextualTextRenderer using the environment effect
+  }
+}
+
+// Internal conformance to AnimatableEffectMarkerProtocol
+extension AnimatableEffectMarker: AnimatableEffectMarkerProtocol {
+  var effectTypeID: String {
+    Self.markerID
+  }
+}
+
+// MARK: - View Modifier
+
+/// A view modifier that provides an animatable effect through the environment.
+struct AnimatableEffectModifier<Effect: TextRunEffect>: ViewModifier, @MainActor Animatable {
+  var effect: Effect
+
+  var animatableData: Effect.AnimatableData {
+    get { effect.animatableData }
+    set { effect.animatableData = newValue }
+  }
+
+  func body(content: Content) -> some View {
+    content.environment(\.animatableEffect, AnyAnimatableEffect(effect))
+  }
+}
+
+// MARK: - View Extension
+
+extension TextualNamespace where Base: View {
+  /// Applies an animatable text effect to the view.
+  ///
+  /// Use this modifier in combination with `AnimatableEffectMarker` to enable
+  /// SwiftUI animations for text effects:
+  ///
+  /// ```swift
+  /// @State private var progress: CGFloat = 0
+  ///
+  /// InlineText(markdown: "**Animated text**")
+  ///   .textual.inlineStyle(
+  ///     InlineStyle().strong(EffectProperty(AnimatableEffectMarker<HighlightEffect>()))
+  ///   )
+  ///   .textual.animatableEffect(HighlightEffect(progress: progress))
+  ///   .onAppear {
+  ///     withAnimation(.easeInOut(duration: 1)) {
+  ///       progress = 1
+  ///     }
+  ///   }
+  /// ```
+  ///
+  /// - Parameter effect: The effect to apply and animate.
+  /// - Returns: A view with the animatable effect applied.
+  @MainActor
+  public func animatableEffect<Effect: TextRunEffect>(_ effect: Effect) -> some View {
+    base.modifier(AnimatableEffectModifier(effect: effect))
+  }
+}

--- a/Sources/Textual/Internal/TextRenderer/TextEffectAttribute.swift
+++ b/Sources/Textual/Internal/TextRenderer/TextEffectAttribute.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+// MARK: - Overview
+//
+// `TextEffectAttribute` is a SwiftUI `TextAttribute` used to mark text runs that
+// should receive custom drawing effects during `Text` layout and rendering.
+//
+// When a `TextRunEffect` is applied through the `TextProperty` system, it is stored
+// in the `AttributeContainer` via `TextEffectAttributeKey` as an `AnyTextRunEffect`.
+// During `Text` construction, `TextBuilder` reads this stored effect and attaches
+// `TextEffectAttribute` to the `Text`. `TextualTextRenderer` then reads this attribute
+// to determine which runs need custom drawing.
+
+struct TextEffectAttribute: TextAttribute {
+  let effect: AnyTextRunEffect
+}
+
+extension Text.Layout.Run {
+  /// Returns the text run effect applied to this run, if any.
+  var textEffect: AnyTextRunEffect? {
+    self[TextEffectAttribute.self]?.effect
+  }
+}
+
+/// The attribute key for storing text effects in `AttributeContainer`.
+enum TextEffectAttributeKey: AttributedStringKey {
+  typealias Value = AnyTextRunEffect
+
+  static let name = "Textual.TextEffect"
+}
+
+/// An attribute scope for text effect attributes.
+extension AttributeScopes {
+  struct TextualEffectAttributes: AttributeScope {
+    let textualEffect: TextEffectAttributeKey
+  }
+
+  var textualEffect: TextualEffectAttributes.Type { TextualEffectAttributes.self }
+}
+
+extension AttributeContainer {
+  public var textualEffect: AnyTextRunEffect? {
+    get { self[TextEffectAttributeKey.self] }
+    set { self[TextEffectAttributeKey.self] = newValue }
+  }
+}
+
+extension AttributedString.Runs.Run {
+  /// Returns the text run effect applied to this run, if any.
+  var textualEffect: AnyTextRunEffect? {
+    self[TextEffectAttributeKey.self]
+  }
+}

--- a/Sources/Textual/Internal/TextRenderer/TextualTextRenderer.swift
+++ b/Sources/Textual/Internal/TextRenderer/TextualTextRenderer.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+// MARK: - Overview
+//
+// `TextualTextRenderer` is the core text renderer for Textual. It handles:
+//
+// 1. Drawing animatable effects (from environment, when provided)
+// 2. Drawing static `TextRunEffect` effects
+// 3. Drawing the text itself
+//
+// The renderer integrates with SwiftUI's `TextRenderer` protocol (iOS 18+/macOS 15+)
+// to provide a unified rendering pipeline that supports both standard text attributes
+// and custom drawing effects.
+//
+// Static effects are applied through the `TextProperty` system and stored in the
+// `AttributeContainer`. Animatable effects are passed through the environment
+// and provided to this renderer by `TextFragment`.
+
+struct TextualTextRenderer: TextRenderer {
+  var animatableEffect: AnyAnimatableEffect?
+
+  init(animatableEffect: AnyAnimatableEffect? = nil) {
+    self.animatableEffect = animatableEffect
+  }
+
+  func draw(layout: Text.Layout, in ctx: inout GraphicsContext) {
+    // 1. Draw run effects (behind text)
+    drawRunEffects(layout: layout, in: &ctx)
+
+    // 2. Draw each line and run
+    for line in layout {
+      for run in line {
+        ctx.draw(run)
+      }
+    }
+  }
+
+  /// Draws custom effects for runs that have effect attributes.
+  private func drawRunEffects(layout: Text.Layout, in ctx: inout GraphicsContext) {
+    for line in layout {
+      for run in line {
+        // Check for animatable effect marker first
+        if let marker = run[AnimatableEffectMarkerAttribute.self],
+           let effect = animatableEffect,
+           marker.effectTypeID == effect.markerID {
+          effect.draw(run: run, in: &ctx)
+        }
+        // Fall back to static effects
+        else if let effect = run.textEffect {
+          effect.draw(run: run, in: &ctx)
+        }
+      }
+    }
+  }
+}

--- a/Sources/Textual/TextProperty/EffectProperty.swift
+++ b/Sources/Textual/TextProperty/EffectProperty.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+// MARK: - Overview
+//
+// `EffectProperty` wraps a `TextRunEffect` as a `TextProperty`, enabling custom
+// drawing effects to be used within the `InlineStyle` system.
+//
+// When applied, the effect is stored in the `AttributeContainer` so that
+// `TextualTextRenderer` can later retrieve and execute it during rendering.
+
+/// A text property that applies a custom drawing effect.
+///
+/// Use `EffectProperty` to wrap a `TextRunEffect` for use with `InlineStyle`:
+///
+/// ```swift
+/// InlineText(markdown: "This is **highlighted** text")
+///   .textual.inlineStyle(
+///     InlineStyle()
+///       .strong(.effect(HighlightEffect(color: .yellow)))
+///   )
+/// ```
+public struct EffectProperty<Effect: TextRunEffect>: TextProperty {
+  private let effect: Effect
+
+  /// Creates an effect property with the given effect.
+  public init(_ effect: Effect) {
+    self.effect = effect
+  }
+
+  public func apply(in attributes: inout AttributeContainer, environment: TextEnvironmentValues) {
+    attributes.textualEffect = AnyTextRunEffect(effect)
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.effect == rhs.effect
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(effect)
+  }
+}
+
+extension AnyTextProperty {
+  /// Creates a text property that applies a custom drawing effect.
+  ///
+  /// - Parameter effect: The effect to apply.
+  /// - Returns: A text property that applies the effect.
+  public static func effect<E: TextRunEffect>(_ effect: E) -> AnyTextProperty {
+    AnyTextProperty(EffectProperty(effect))
+  }
+}

--- a/Sources/Textual/TextProperty/TextRunEffect.swift
+++ b/Sources/Textual/TextProperty/TextRunEffect.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+// MARK: - Overview
+//
+// `TextRunEffect` defines a custom drawing effect that can be applied to text runs.
+//
+// Unlike standard text properties that modify `AttributeContainer`, effects provide
+// full control over rendering via `GraphicsContext`. This enables advanced visual
+// treatments like animated highlights, custom underlines, or gradient backgrounds
+// that aren't possible with standard text attributes.
+//
+// Effects are applied through the `TextProperty` system using `.effect(_:)` and
+// rendered by `TextualTextRenderer` during the text drawing phase.
+
+/// A custom drawing effect for text runs.
+///
+/// Conform to `TextRunEffect` to create custom visual treatments for inline text.
+/// Effects have full access to `GraphicsContext` and can draw before or after the text.
+///
+/// ## Basic Usage
+///
+/// ```swift
+/// struct HighlightEffect: TextRunEffect {
+///   var color: Color
+///
+///   func draw(run: Text.Layout.Run, in context: inout GraphicsContext) {
+///     let bounds = run.typographicBounds.rect
+///     context.fill(Path(bounds), with: .color(color.opacity(0.3)))
+///   }
+/// }
+/// ```
+///
+/// ## Animation
+///
+/// To animate effect properties, implement `animatableData` and use
+/// `AnimatableEffectMarker` with the `.textual.animatableEffect()` modifier:
+///
+/// ```swift
+/// struct AnimatedHighlightEffect: TextRunEffect {
+///   var progress: CGFloat
+///
+///   var animatableData: CGFloat {
+///     get { progress }
+///     set { progress = newValue }
+///   }
+///
+///   func draw(run: Text.Layout.Run, in context: inout GraphicsContext) {
+///     let bounds = run.typographicBounds.rect
+///     let width = bounds.width * progress
+///     context.fill(Path(CGRect(x: bounds.minX, y: bounds.minY, width: width, height: bounds.height)),
+///                  with: .color(.yellow.opacity(0.3)))
+///   }
+/// }
+///
+/// // In your view:
+/// @State var progress: CGFloat = 0
+///
+/// InlineText(markdown: "**Important text**")
+///   .textual.inlineStyle(
+///     InlineStyle().strong(EffectProperty(AnimatableEffectMarker<AnimatedHighlightEffect>()))
+///   )
+///   .textual.animatableEffect(AnimatedHighlightEffect(progress: progress))
+///   .onAppear {
+///     withAnimation(.easeInOut(duration: 1)) { progress = 1 }
+///   }
+/// ```
+public protocol TextRunEffect: Sendable, Hashable {
+  /// The type of animatable data for this effect.
+  associatedtype AnimatableData: VectorArithmetic = EmptyAnimatableData
+
+  /// The animatable data for this effect.
+  ///
+  /// Implement this property to enable smooth animations when effect properties change.
+  var animatableData: AnimatableData { get set }
+
+  /// Draws the effect for the given text run.
+  ///
+  /// This method is called by the text renderer for each run that has this effect applied.
+  /// Draw behind the text by calling this before `context.draw(layout)`, or draw on top
+  /// by calling it after.
+  ///
+  /// - Parameters:
+  ///   - run: The text run to draw the effect for.
+  ///   - context: The graphics context to draw into.
+  func draw(run: Text.Layout.Run, in context: inout GraphicsContext)
+}
+
+extension TextRunEffect where AnimatableData == EmptyAnimatableData {
+  public var animatableData: EmptyAnimatableData {
+    get { EmptyAnimatableData() }
+    set {}
+  }
+}
+
+/// A type-erased wrapper for `TextRunEffect`.
+public struct AnyTextRunEffect: Sendable, Hashable {
+  private let box: any EffectBox
+
+  /// Creates a type-erased wrapper around a concrete effect.
+  public init<Effect: TextRunEffect>(_ effect: Effect) {
+    self.box = ConcreteEffectBox(effect)
+  }
+
+  func draw(run: Text.Layout.Run, in context: inout GraphicsContext) {
+    box.draw(run: run, in: &context)
+  }
+
+  /// Returns the marker ID if this is an animatable effect marker, nil otherwise.
+  var animatableEffectMarkerID: String? {
+    box.animatableEffectMarkerID
+  }
+
+  public static func == (lhs: AnyTextRunEffect, rhs: AnyTextRunEffect) -> Bool {
+    lhs.box.isEqual(to: rhs.box)
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    box.hash(into: &hasher)
+  }
+}
+
+// MARK: - Effect Box Protocol
+
+private protocol EffectBox: Sendable {
+  func draw(run: Text.Layout.Run, in context: inout GraphicsContext)
+  func isEqual(to other: any EffectBox) -> Bool
+  func hash(into hasher: inout Hasher)
+  var animatableEffectMarkerID: String? { get }
+}
+
+private struct ConcreteEffectBox<Effect: TextRunEffect>: EffectBox {
+  var effect: Effect
+
+  init(_ effect: Effect) {
+    self.effect = effect
+  }
+
+  func draw(run: Text.Layout.Run, in context: inout GraphicsContext) {
+    effect.draw(run: run, in: &context)
+  }
+
+  func isEqual(to other: any EffectBox) -> Bool {
+    guard let other = other as? ConcreteEffectBox<Effect> else { return false }
+    return effect == other.effect
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(effect)
+  }
+
+  var animatableEffectMarkerID: String? {
+    (effect as? any AnimatableEffectMarkerProtocol)?.effectTypeID
+  }
+}
+
+/// Protocol to identify AnimatableEffectMarker types.
+protocol AnimatableEffectMarkerProtocol {
+  var effectTypeID: String { get }
+}

--- a/Tests/TextualTests/TextProperty/TextRunEffectTests.swift
+++ b/Tests/TextualTests/TextProperty/TextRunEffectTests.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import Testing
+
+@testable import Textual
+
+// MARK: - Test Effect
+
+/// A simple test effect for unit testing.
+private struct TestEffect: TextRunEffect {
+  var value: CGFloat
+
+  var animatableData: CGFloat {
+    get { value }
+    set { value = newValue }
+  }
+
+  func draw(run: Text.Layout.Run, in context: inout GraphicsContext) {
+    // No-op for testing
+  }
+}
+
+struct TextRunEffectTests {
+  @Test func effectPropertyAppliesAttribute() {
+    let effect = TestEffect(value: 0.5)
+    let property = EffectProperty(effect)
+
+    var attributes = AttributeContainer()
+    property.apply(in: &attributes, environment: TextEnvironmentValues())
+
+    #expect(attributes.textualEffect != nil)
+  }
+
+  @Test func effectAnimatableData() {
+    var effect = TestEffect(value: 0.0)
+
+    #expect(effect.animatableData == 0.0)
+
+    effect.animatableData = 0.75
+    #expect(effect.value == 0.75)
+  }
+
+  @Test func effectEquality() {
+    let effect1 = TestEffect(value: 1.0)
+    let effect2 = TestEffect(value: 1.0)
+    let effect3 = TestEffect(value: 0.5)
+
+    #expect(effect1 == effect2)
+    #expect(effect1 != effect3)
+  }
+
+  @Test func anyTextRunEffectWrapsEffect() {
+    let effect = TestEffect(value: 1.0)
+    let anyEffect1 = AnyTextRunEffect(effect)
+    let anyEffect2 = AnyTextRunEffect(effect)
+
+    #expect(anyEffect1 == anyEffect2)
+  }
+
+  @Test func anyTextRunEffectInequality() {
+    let effect1 = TestEffect(value: 1.0)
+    let effect2 = TestEffect(value: 0.5)
+    let anyEffect1 = AnyTextRunEffect(effect1)
+    let anyEffect2 = AnyTextRunEffect(effect2)
+
+    #expect(anyEffect1 != anyEffect2)
+  }
+
+  @Test func effectPropertyEquality() {
+    let effect1 = TestEffect(value: 1.0)
+    let effect2 = TestEffect(value: 1.0)
+    let effect3 = TestEffect(value: 0.5)
+
+    let property1 = EffectProperty(effect1)
+    let property2 = EffectProperty(effect2)
+    let property3 = EffectProperty(effect3)
+
+    #expect(property1 == property2)
+    #expect(property1 != property3)
+  }
+
+  @Test func animatableEffectMarkerReturnsMarkerID() {
+    let marker = AnimatableEffectMarker<TestEffect>()
+    let anyEffect = AnyTextRunEffect(marker)
+
+    // markerID uses String(reflecting:) which includes the full module path
+    let markerID = anyEffect.animatableEffectMarkerID
+    #expect(markerID != nil)
+    #expect(markerID?.contains("TestEffect") == true)
+  }
+
+  @Test func regularEffectReturnsNilMarkerID() {
+    let effect = TestEffect(value: 1.0)
+    let anyEffect = AnyTextRunEffect(effect)
+
+    #expect(anyEffect.animatableEffectMarkerID == nil)
+  }
+
+  @Test func attributedStringHasTextEffect() {
+    let effect = TestEffect(value: 1.0)
+
+    // String without effect
+    let plainString = AttributedString("Hello")
+    #expect(plainString.hasTextEffect == false)
+
+    // String with effect
+    var container = AttributeContainer()
+    container.textualEffect = AnyTextRunEffect(effect)
+    let styledString = AttributedString("World", attributes: container)
+    #expect(styledString.hasTextEffect == true)
+
+    // Combined string
+    var combined = plainString
+    combined.append(styledString)
+    #expect(combined.hasTextEffect == true)
+  }
+}


### PR DESCRIPTION
This PR adds a new capability to Textual: **custom drawing effects for text runs**. By conforming to the `TextRunEffect` protocol, users can create visual treatments that go beyond standard text attributes—such as animated highlights, custom underlines, gradient backgrounds, or any effect achievable with `GraphicsContext`.

### Motivation

While Textual's `InlineStyle` system covers standard text attributes (font, color, underline, etc.), there's no way to apply custom visual effects that require direct drawing control. This feature fills that gap by integrating with SwiftUI's `TextRenderer` protocol.

### Features

#### 1. Static Effects

Create custom effects by conforming to `TextRunEffect`:

```swift
struct HighlightEffect: TextRunEffect {
  var color: Color

  func draw(run: Text.Layout.Run, in context: inout GraphicsContext) {
    let bounds = run.typographicBounds.rect
    context.fill(Path(bounds), with: .color(color.opacity(0.3)))
  }
}

InlineText(markdown: "This is **highlighted** text")
  .textual.inlineStyle(
    InlineStyle()
      .strong(EffectProperty(HighlightEffect(color: .yellow)))
  )
```

#### 2. Animated Effects

Effects can participate in SwiftUI animations using `AnimatableEffectMarker` and `.textual.animatableEffect()`:

```swift
struct AnimatedHighlightEffect: TextRunEffect {
  var progress: CGFloat
  
  var animatableData: CGFloat {
    get { progress }
    set { progress = newValue }
  }
  
  func draw(run: Text.Layout.Run, in context: inout GraphicsContext) {
    // Draw based on progress...
  }
}

@State private var progress: CGFloat = 0

InlineText(markdown: "**Animated text**")
  .textual.inlineStyle(
    InlineStyle()
      .strong(EffectProperty(AnimatableEffectMarker<AnimatedHighlightEffect>()))
  )
  .textual.animatableEffect(
    AnimatedHighlightEffect(progress: progress)
  )
  .onAppear {
    withAnimation(.easeInOut(duration: 1)) {
      progress = 1
    }
  }
```

### Demo

https://github.com/user-attachments/assets/c7233585-f1ee-440e-b5bc-1b212497114b

### Implementation Details

| File                        | Description                                                                       |
|-----------------------------|-----------------------------------------------------------------------------------|
| `TextRunEffect.swift`       | Protocol definition with `Animatable` support and `AnyTextRunEffect` type erasure |
| `EffectProperty.swift`      | Integrates effects into the `TextProperty` system                                 |
| `TextEffectAttribute.swift` | Stores effects in `AttributeContainer`                                            |
| `TextualTextRenderer.swift` | Custom `TextRenderer` that draws effects before text                              |
| `AnimatableEffect.swift`    | Environment-based animation support with `AnimatableEffectMarker`                 |
| `TextFragment.swift`        | Conditionally applies renderer only when effects are present                      |

### Design Decisions

1. **Conditional rendering**: The custom `TextualTextRenderer` is only applied when effects are actually present (`animatableEffect != nil || content.hasTextEffect`). This preserves the native SwiftUI text rendering path for content without effects, maintaining visual consistency and passing existing snapshot tests.

2. **Two-step animation pattern**: Due to type erasure in `AttributeContainer`, animated effects use a marker/environment pattern:
   - `AnimatableEffectMarker<Effect>` marks which runs receive the effect
   - `.textual.animatableEffect()` provides the actual effect instance that participates in SwiftUI's animation interpolation

### Documentation

README has been updated with:
- Basic effect usage example
- Collapsible section for animated effects
- Complete code examples
