### PR TITLE
Catalyst support

### DIFF
--- a/Examples/TextualDemo/TextualDemo.xcodeproj/project.pbxproj
+++ b/Examples/TextualDemo/TextualDemo.xcodeproj/project.pbxproj
@@ -300,7 +300,8 @@
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx maccatalyst xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -353,7 +354,8 @@
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx maccatalyst xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ let package = Package(
         .process("Internal/Highlighter/Prism")
       ],
       swiftSettings: [
-        .define("TEXTUAL_ENABLE_LINKS", .when(platforms: [.macOS, .iOS, .watchOS, .visionOS])),
-        .define("TEXTUAL_ENABLE_TEXT_SELECTION", .when(platforms: [.macOS, .iOS, .visionOS])),
+        .define("TEXTUAL_ENABLE_LINKS", .when(platforms: [.macOS, .macCatalyst, .iOS, .watchOS, .visionOS])),
+        .define("TEXTUAL_ENABLE_TEXT_SELECTION", .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS])),
       ]
     ),
     .testTarget(
@@ -46,7 +46,7 @@ let package = Package(
       ],
       resources: [.copy("Fixtures")],
       swiftSettings: [
-        .define("TEXTUAL_ENABLE_TEXT_SELECTION", .when(platforms: [.macOS, .iOS, .visionOS]))
+        .define("TEXTUAL_ENABLE_TEXT_SELECTION", .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS]))
       ]
     ),
   ]

--- a/Sources/Textual/Internal/Font/PlatformFont.swift
+++ b/Sources/Textual/Internal/Font/PlatformFont.swift
@@ -7,7 +7,7 @@ import SwiftUI
 // UITraitCollection, ensuring font descriptors reflect the same Dynamic Type and Bold Text
 // settings as the SwiftUI environment.
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
   typealias PlatformFont = NSFont
   typealias FontDescriptor = NSFontDescriptor
 #elseif canImport(UIKit)
@@ -20,7 +20,7 @@ extension FontDescriptor {
     withTextStyle style: Font.TextStyle,
     in environment: TextEnvironmentValues
   ) -> FontDescriptor {
-    #if canImport(AppKit)
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
       preferredFontDescriptor(forTextStyle: .init(style))
     #elseif canImport(UIKit) && !os(watchOS)
       preferredFontDescriptor(

--- a/Sources/Textual/Internal/Helpers/PlatformImage.swift
+++ b/Sources/Textual/Internal/Helpers/PlatformImage.swift
@@ -12,7 +12,7 @@ extension PlatformImage {
     bundle: Bundle?,
     environment: ColorEnvironmentValues
   ) -> PlatformImage? {
-    #if canImport(AppKit)
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
       guard let appearance = NSAppearance(environment: environment) else {
         return nil
       }
@@ -48,7 +48,7 @@ extension SwiftUI.Image {
   }
 }
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
   extension NSAppearance {
     convenience init?(environment: ColorEnvironmentValues) {
       switch (environment.colorScheme, environment.colorSchemeContrast) {

--- a/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextInteractionOverlay.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextInteractionOverlay.swift
@@ -1,4 +1,4 @@
-#if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit)
+#if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit) && !targetEnvironment(macCatalyst)
   import SwiftUI
 
   // MARK: - Overview

--- a/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextSelectionInteraction.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextSelectionInteraction.swift
@@ -1,4 +1,4 @@
-#if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit)
+#if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit) && !targetEnvironment(macCatalyst)
   import SwiftUI
 
   // MARK: - Overview

--- a/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextSelectionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextSelectionView.swift
@@ -1,4 +1,4 @@
-#if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit)
+#if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit) && !targetEnvironment(macCatalyst)
   import SwiftUI
 
   // MARK: - Overview

--- a/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
@@ -1,4 +1,4 @@
-#if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit)
+#if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit) && !targetEnvironment(macCatalyst)
   import SwiftUI
 
   // MARK: - Overview

--- a/Sources/Textual/Internal/TextInteraction/Shared/TextSelectionBackground.swift
+++ b/Sources/Textual/Internal/TextInteraction/Shared/TextSelectionBackground.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct TextSelectionBackground: ViewModifier {
   func body(content: Content) -> some View {
-    #if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit)
+    #if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit) && !targetEnvironment(macCatalyst)
       content
         .backgroundPreferenceValue(Text.LayoutKey.self) { value in
           if let anchoredLayout = value.first {

--- a/Sources/Textual/StructuredText/Style/CodeBlockProxy.swift
+++ b/Sources/Textual/StructuredText/Style/CodeBlockProxy.swift
@@ -16,7 +16,7 @@ extension StructuredText {
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     public func copyToPasteboard() {
-      #if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit)
+      #if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit) && !targetEnvironment(macCatalyst)
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 


### PR DESCRIPTION
The package wasn't building for Mac Catalyst. 

Many AppKit features are not available in Catalyst, but the `#if` only checked for `canImport(AppKit)`, which is technically true for Catalyst. I added `&& !targetEnvironment(macCatalyst)` when necessary, so that the UIKit APIs are used.

The demo app now also builds and runs on Mac Catalyst.