### PR TITLE
fix(iOS): clear text selection on tap, matching macOS behavior

### DIFF
--- a/Sources/Textual/Internal/TextInteraction/UIKit/UITextInteractionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/UIKit/UITextInteractionView.swift
@@ -109,10 +109,11 @@
 
     @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
       let location = gesture.location(in: self)
-      guard let url = model.url(for: location) else {
-        return
+      if let url = model.url(for: location) {
+        openURL(url)
+      } else {
+        model.selectedRange = nil
       }
-      openURL(url)
     }
 
     @objc private func share(_ sender: Any?) {


### PR DESCRIPTION
## Summary

On iOS, tapping outside selected text does not clear the selection — users must double-tap another word to deselect. On macOS, single-clicking anywhere correctly clears the selection via `resetSelection()` in `NSTextInteractionView.mouseDown`.

The root cause is in `UITextInteractionView.handleTap`: it only handles URL taps and returns early otherwise, leaving the active selection intact.

**Before:**
```swift
@objc private func handleTap(_ gesture: UITapGestureRecognizer) {
  let location = gesture.location(in: self)
  guard let url = model.url(for: location) else {
    return  // ← selection stays active
  }
  openURL(url)
}
```

**After:**
```swift
@objc private func handleTap(_ gesture: UITapGestureRecognizer) {
  let location = gesture.location(in: self)
  if let url = model.url(for: location) {
    openURL(url)
  } else {
    model.selectedRange = nil  // ← clear selection, matching macOS
  }
}
```

This brings iOS in line with the macOS behavior where `NSTextInteractionView.mouseDown` calls `resetSelection()` (which sets `model.selectedRange = nil`) on single click.

## Test plan

- [ ] Select text on iOS → tap empty space → selection clears
- [ ] Select text on iOS → tap a link → link opens (no regression)
- [ ] Verify macOS selection behavior unchanged