### PR TITLE
Address performance problems for StructuredText code blocks

### DIFF
--- a/Sources/Textual/Internal/Highlighter/HighlightedTextFragment.swift
+++ b/Sources/Textual/Internal/Highlighter/HighlightedTextFragment.swift
@@ -29,13 +29,13 @@ struct HighlightedTextFragment: View {
   }
 
   var body: some View {
+    // Convert to an owned String before the async boundary
+    let code = String(content.characters[...])
+
     TextFragment(model.highlightedCode ?? AttributedString(content))
       .foregroundStyle(theme.foregroundColor)
-      .task(id: content) {
-        await model.tokenize(
-          content: content,
-          languageHint: languageHint
-        )
+      .task(id: code) {
+        await model.tokenize(code: code, languageHint: languageHint, theme: theme)
       }
       .onChange(of: Tuple(model.tokens, textEnvironment)) { _, newValue in
         model.highlight(

--- a/Sources/Textual/Internal/Highlighter/HighlightedTextFragment.swift
+++ b/Sources/Textual/Internal/Highlighter/HighlightedTextFragment.swift
@@ -53,11 +53,12 @@ extension HighlightedTextFragment {
     var tokens: [CodeToken] = []
     var highlightedCode: AttributedString?
 
-    func tokenize(content: AttributedSubstring, languageHint: String?) async {
-      let code = String(content.characters[...])
+    func tokenize(code: String, languageHint: String?, theme: StructuredText.HighlighterTheme) async {
       tokens = [CodeToken(content: code, type: .plain)]
 
-      if let tokenizer = CodeTokenizer.shared, let languageHint {
+      // Skip the expensive tokenizer when the theme has no token properties
+      if !theme.tokenProperties.isEmpty,
+         let tokenizer = CodeTokenizer.shared, let languageHint {
         tokens = await tokenizer.tokenize(code: code, language: languageHint)
       }
     }

--- a/Sources/Textual/Internal/TextFragment/TextBuilder.swift
+++ b/Sources/Textual/Internal/TextFragment/TextBuilder.swift
@@ -96,9 +96,7 @@ extension Text {
       return text
     }
 
-    self = textValues.reduce(Text(verbatim: "")) { partialResult, text in
-      Text("\(partialResult)\(text)")
-    }
+    self = textValues.balancedConcatenation()
   }
 
   private init(placeholderSize size: CGSize) {
@@ -127,6 +125,26 @@ extension AttributedStringProtocol {
       },
       uniquingKeysWith: { existing, _ in existing }
     )
+  }
+}
+
+// Concatenate Text views using a balanced binary tree to keep the nesting
+// depth at O(log N). A linear reduce creates O(N) depth, which causes
+// a stack overflow in SwiftUI's recursive Text.resolve() for long runs
+// (e.g. syntax-highlighted code blocks with hundreds of tokens).
+extension Array where Element == Text {
+  fileprivate func balancedConcatenation() -> Text {
+    switch count {
+    case 0:
+      return Text(verbatim: "")
+    case 1:
+      return self[0]
+    default:
+      let mid = count / 2
+      let lhs = Array(self[..<mid]).balancedConcatenation()
+      let rhs = Array(self[mid...]).balancedConcatenation()
+      return Text("\(lhs)\(rhs)")
+    }
   }
 }
 


### PR DESCRIPTION
This PR improves the reliability of `StructuredText` when rendering large code blocks and makes `Textual` more suited to streaming.

## Context
It has previously been observed that the library may cause a crash for large markdown documents as discussed in #23 

If using `StructuredText` for streaming content (frequent layout updates), this problem can be excessive.

## The causes
I found a few things that influence this behaviour:

### 1) Stack overflow in `TextBuilder` concatenation
`TextBuilder` constructs the final Text view by reducing an array of per-run Text values with string interpolation.

```swift
self = textValues.reduce(Text(verbatim: "")) { partialResult, text in
    Text("\(partialResult)\(text)")
 }
```

This creates an unbalanced tree where each step nests the previous result on the left. For syntax-highlighted code blocks, it creates a very deep `Text` tree. When SwiftUI resolves it, `Text.resolve()` recurses through every level and with hundreds of code block tokens, causes a stack overflow.

The change here balances that tree, so that each side has roughly equal depth. This makes a stack overflow from excessive recursion depth very unlikely.

### 2) Borrowed `AttributedSubstring` captured across async boundary
`HighlighedTextFragment` passes its content directly to a task closure for tokenisation. `AttributedSubstring` borrows storage from its parent `AttributedString`, so if the content updates rapidly (like when streaming), the parent can be replaced while the async task may still reference the old substring storage.

### 3) Redundant tokenisation when there is no highlighting
When content changes frequently, `HighlightedTextFragment` re-tokenises on every update. In the streaming scenario, this leads to performance degradation. If syntax highlighting is disabled, the tokenisation pass can be skipped, which allows downstream applications to disable syntax while streaming and only pay the tokenisation cost once, when done.