### PR TITLE
fix(macOS): nonisolated isFlipped on NSTextInteractionView

### DIFF
--- a/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
@@ -16,7 +16,12 @@
     var openURL: OpenURLAction
 
     override var acceptsFirstResponder: Bool { true }
-    override var isFlipped: Bool { true }
+
+    /// AppKit may call `isFlipped` while updating tracking areas without an active Swift
+    /// concurrency task. Because `NSView` is `MainActor`, an ordinary `override` runs an
+    /// executor check that can crash (invalid executor reference) in Swift 6 when other
+    /// executors are present in the process. The return value is fixed.
+    nonisolated override var isFlipped: Bool { true }
 
     private var dragStart: TextPosition?
     private var selectionAnchor: TextPosition?


### PR DESCRIPTION
## Summary

`NSTextInteractionView` overrides `isFlipped` to return `true`. On Swift 6, `NSView` members inherit `MainActor` isolation, so that getter runs `_checkExpectedExecutor`.

AppKit can query `isFlipped` from tracking-area machinery (`_NSTrackingAreaAKManager` → `_convertPoint_fromAncestor`) on a path that does not always establish a Swift concurrency task/executor context. In that situation we have seen `EXC_BAD_ACCESS` at a low offset inside `SerialExecutor._isSameExecutor` (invalid executor reference), with the crashing frame attributed to `NSTextInteractionView.isFlipped`.

Because this property is a constant `true`, mark it `nonisolated` so AppKit can read it without executor validation.

## Test plan

- [ ] macOS: build Textual Demo / any host using selectable Textual text; move pointer over rich text / trigger tracking area updates; no crash.
- [ ] `swift build` / existing tests on macOS.
