### PR TITLE
fix(macOS): nonisolated hitTest on NSTextInteractionView

### DIFF
--- a/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
@@ -38,16 +38,21 @@
       fatalError("init(coder:) has not been implemented")
     }
 
-    override func hitTest(_ point: NSPoint) -> NSView? {
-      let localPoint = convert(point, from: superview)
-      let isExcluded = exclusionRects.contains {
-        $0.contains(localPoint)
-      }
+    /// AppKit / SwiftUI hit-test this during hover and tracking-area work; like a nonisolated
+    /// `isFlipped` override, a plain `override` can fault in `_checkExpectedExecutor` (Swift 6)
+    /// on the `@objc` entry path.
+    nonisolated override func hitTest(_ point: NSPoint) -> NSView? {
+      MainActor.assumeIsolated {
+        let localPoint = convert(point, from: superview)
+        let isExcluded = exclusionRects.contains {
+          $0.contains(localPoint)
+        }
 
-      if isExcluded {
-        return nil
-      } else {
-        return super.hitTest(point)
+        if isExcluded {
+          return nil
+        } else {
+          return super.hitTest(point)
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

`NSTextInteractionView` overrides `hitTest(_:)` to respect `exclusionRects`. On Swift 6, `NSView` members inherit `MainActor` isolation, so that method runs `_checkExpectedExecutor` on the `@objc` dispatch path.

SwiftUI hover hit testing can call through to `hitTest` from `mouseMoved` / `NSHostingView.sendHoverEvent` on a path where we have seen `EXC_BAD_ACCESS` inside `swift_getObjectType` while validating the main executor (same general failure mode as nonisolated `isFlipped`, see #42).

Mark `hitTest` `nonisolated` and wrap the implementation in `MainActor.assumeIsolated` (AppKit hit testing is always on the main thread).

## Test plan

- [ ] macOS: build Textual Demo or an app using selectable Textual text in a `ScrollView`; move the pointer over rich text to exercise hover hit testing; no crash.
- [ ] `swift build` / existing tests on macOS.
