### PR TITLE
FIX: Enable link interaction in table

### DIFF
--- a/Sources/Textual/View+Textual.swift
+++ b/Sources/Textual/View+Textual.swift
@@ -96,6 +96,7 @@ extension TextualNamespace where Base: View {
       GeometryReader { geometry in
         content(.init(values, geometry: geometry))
       }
+      .allowsHitTesting(false)
     }
   }
 
@@ -110,6 +111,7 @@ extension TextualNamespace where Base: View {
       GeometryReader { geometry in
         content(.init(values, geometry: geometry))
       }
+      .allowsHitTesting(false)
     }
   }
 


### PR DESCRIPTION
The GeometryReader used for table overlay and background rendering was blocking taps on links