### PR TITLE
Fix linked image markdown parsing

### DIFF
--- a/Sources/Textual/Internal/MarkdownParser/LinkedImageProcessor.swift
+++ b/Sources/Textual/Internal/MarkdownParser/LinkedImageProcessor.swift
@@ -1,0 +1,381 @@
+import Foundation
+
+// Foundation's Markdown parser drops linked images like `[![](image.png)](link)`: empty-alt
+// images disappear entirely, and non-empty alt text keeps only the outer link. This processor
+// works around that by rewriting linked images into ordinary image Markdown before parsing, then
+// restoring the parsed image run with the outer link attached.
+struct LinkedImageProcessor {
+  private let baseURL: URL?
+
+  init(baseURL: URL?) {
+    self.baseURL = baseURL
+  }
+
+  func preprocess(_ input: String) -> Output {
+    var markdown = ""
+    var links: [String: Link] = [:]
+    var index = input.startIndex
+
+    while index < input.endIndex {
+      if let range = codeFenceRange(at: index, in: input) {
+        markdown += input[range]
+        index = range.upperBound
+      } else if let range = codeSpanRange(at: index, in: input) {
+        markdown += input[range]
+        index = range.upperBound
+      } else if let linkedImage = linkedImage(at: index, in: input, tokenIndex: links.count) {
+        markdown += linkedImage.markdown
+        links[linkedImage.token] = linkedImage.link
+        index = linkedImage.range.upperBound
+      } else {
+        markdown.append(input[index])
+        index = input.index(after: index)
+      }
+    }
+
+    return Output(markdown: markdown, links: links)
+  }
+
+  func restore(_ attributedString: AttributedString, from output: Output) -> AttributedString {
+    guard !output.links.isEmpty else {
+      return attributedString
+    }
+
+    var restored = AttributedString()
+
+    for run in attributedString.runs {
+      let substring = attributedString[run.range]
+      let text = String(substring.characters[...])
+
+      guard let link = output.links[text], run.imageURL != nil else {
+        restored.append(substring)
+        continue
+      }
+
+      var replacement = AttributedString(
+        link.altText.isEmpty ? "\u{FFFC}" : link.altText,
+        attributes: run.attributes
+      )
+      replacement.link = destinationURL(from: link.destination)
+
+      restored.append(replacement)
+    }
+
+    return restored
+  }
+
+  private func linkedImage(
+    at index: String.Index,
+    in input: String,
+    tokenIndex: Int
+  ) -> LinkedImage? {
+    guard input[index...].hasPrefix("[![") else {
+      return nil
+    }
+
+    var cursor = input.index(index, offsetBy: 3)
+
+    guard let altText = bracketedContent(startingAt: cursor, closing: "]", in: input) else {
+      return nil
+    }
+
+    cursor = altText.range.upperBound
+
+    guard
+      cursor < input.endIndex,
+      input[cursor] == "(",
+      let imageDestination = parenthesizedContent(startingAt: cursor, in: input)
+    else {
+      return nil
+    }
+
+    cursor = imageDestination.range.upperBound
+
+    guard
+      cursor < input.endIndex,
+      input[cursor] == "]"
+    else {
+      return nil
+    }
+
+    cursor = input.index(after: cursor)
+
+    guard
+      cursor < input.endIndex,
+      input[cursor] == "(",
+      let linkDestination = parenthesizedContent(startingAt: cursor, in: input)
+    else {
+      return nil
+    }
+
+    let token = token(for: tokenIndex, in: input)
+    return LinkedImage(
+      range: index..<linkDestination.range.upperBound,
+      markdown: "![\(token)](\(imageDestination.content))",
+      token: token,
+      link: Link(
+        altText: altText.content,
+        destination: linkDestination.content
+      )
+    )
+  }
+
+  private func bracketedContent(
+    startingAt start: String.Index,
+    closing: Character,
+    in input: String
+  ) -> Content? {
+    var index = start
+
+    while index < input.endIndex {
+      if input[index] == "\\" {
+        index = input.index(after: index)
+        if index < input.endIndex {
+          index = input.index(after: index)
+        }
+        continue
+      }
+
+      if input[index] == closing {
+        return Content(
+          content: String(input[start..<index]),
+          range: start..<input.index(after: index)
+        )
+      }
+
+      index = input.index(after: index)
+    }
+
+    return nil
+  }
+
+  private func parenthesizedContent(
+    startingAt start: String.Index,
+    in input: String
+  ) -> Content? {
+    var index = input.index(after: start)
+    var depth = 0
+
+    while index < input.endIndex {
+      if input[index] == "\\" {
+        index = input.index(after: index)
+        if index < input.endIndex {
+          index = input.index(after: index)
+        }
+        continue
+      }
+
+      if input[index] == "(" {
+        depth += 1
+      } else if input[index] == ")" {
+        guard depth > 0 else {
+          return Content(
+            content: String(input[input.index(after: start)..<index]),
+            range: start..<input.index(after: index)
+          )
+        }
+        depth -= 1
+      }
+
+      index = input.index(after: index)
+    }
+
+    return nil
+  }
+
+  private func codeSpanRange(at index: String.Index, in input: String) -> Range<String.Index>? {
+    guard input[index] == "`" else {
+      return nil
+    }
+
+    let delimiter = backtickDelimiter(at: index, in: input)
+    var cursor = delimiter.upperBound
+
+    while cursor < input.endIndex {
+      guard input[cursor] == "`" else {
+        cursor = input.index(after: cursor)
+        continue
+      }
+
+      let closingDelimiter = backtickDelimiter(at: cursor, in: input)
+      if input[closingDelimiter] == input[delimiter] {
+        return index..<closingDelimiter.upperBound
+      }
+
+      cursor = closingDelimiter.upperBound
+    }
+
+    return nil
+  }
+
+  private func codeFenceRange(at index: String.Index, in input: String) -> Range<String.Index>? {
+    guard
+      isLineStart(index, in: input),
+      let openingFence = fence(at: index, in: input)
+    else {
+      return nil
+    }
+
+    var cursor = lineEnd(after: openingFence.range.upperBound, in: input)
+
+    while cursor < input.endIndex {
+      let lineStart = cursor
+
+      if let closingFence = fence(at: lineStart, in: input),
+        closingFence.marker == openingFence.marker,
+        closingFence.length >= openingFence.length
+      {
+        return index..<lineEnd(after: closingFence.range.upperBound, in: input)
+      }
+
+      cursor = lineEnd(after: cursor, in: input)
+    }
+
+    return index..<input.endIndex
+  }
+
+  private func fence(at index: String.Index, in input: String) -> Fence? {
+    var cursor = index
+    var indentation = 0
+
+    while cursor < input.endIndex, input[cursor] == " ", indentation < 4 {
+      indentation += 1
+      cursor = input.index(after: cursor)
+    }
+
+    guard indentation < 4, cursor < input.endIndex else {
+      return nil
+    }
+
+    let marker = input[cursor]
+    guard marker == "`" || marker == "~" else {
+      return nil
+    }
+
+    var end = cursor
+    var length = 0
+    while end < input.endIndex, input[end] == marker {
+      length += 1
+      end = input.index(after: end)
+    }
+
+    guard length >= 3 else {
+      return nil
+    }
+
+    return Fence(marker: marker, length: length, range: cursor..<end)
+  }
+
+  private func backtickDelimiter(
+    at index: String.Index,
+    in input: String
+  ) -> Range<String.Index> {
+    var end = index
+
+    while end < input.endIndex, input[end] == "`" {
+      end = input.index(after: end)
+    }
+
+    return index..<end
+  }
+
+  private func lineEnd(after index: String.Index, in input: String) -> String.Index {
+    var cursor = index
+
+    while cursor < input.endIndex {
+      let next = input.index(after: cursor)
+      if input[cursor] == "\n" {
+        return next
+      }
+      cursor = next
+    }
+
+    return input.endIndex
+  }
+
+  private func isLineStart(_ index: String.Index, in input: String) -> Bool {
+    index == input.startIndex || input[input.index(before: index)] == "\n"
+  }
+
+  private func token(for index: Int, in input: String) -> String {
+    var token = "\u{E000}TEXTUAL_LINKED_IMAGE_\(index)\u{E000}"
+    var offset = index
+
+    while input.contains(token) {
+      offset += 1
+      token = "\u{E000}TEXTUAL_LINKED_IMAGE_\(offset)\u{E000}"
+    }
+
+    return token
+  }
+
+  private func destinationURL(from markdownDestination: String) -> URL? {
+    guard let destination = firstDestination(in: markdownDestination) else {
+      return nil
+    }
+
+    return URL(string: destination, relativeTo: baseURL)
+  }
+
+  private func firstDestination(in markdownDestination: String) -> String? {
+    let trimmed = markdownDestination.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard !trimmed.isEmpty else {
+      return nil
+    }
+
+    if trimmed.first == "<", let end = trimmed.dropFirst().firstIndex(of: ">") {
+      return String(trimmed[trimmed.index(after: trimmed.startIndex)..<end])
+    }
+
+    var index = trimmed.startIndex
+
+    while index < trimmed.endIndex {
+      if trimmed[index] == "\\" {
+        index = trimmed.index(after: index)
+        if index < trimmed.endIndex {
+          index = trimmed.index(after: index)
+        }
+        continue
+      }
+
+      if trimmed[index].isWhitespace {
+        break
+      }
+
+      index = trimmed.index(after: index)
+    }
+
+    return String(trimmed[..<index])
+  }
+}
+
+extension LinkedImageProcessor {
+  struct Output {
+    let markdown: String
+    let links: [String: Link]
+  }
+
+  struct Link {
+    let altText: String
+    let destination: String
+  }
+
+  private struct LinkedImage {
+    let range: Range<String.Index>
+    let markdown: String
+    let token: String
+    let link: Link
+  }
+
+  private struct Content {
+    let content: String
+    let range: Range<String.Index>
+  }
+
+  private struct Fence {
+    let marker: Character
+    let length: Int
+    let range: Range<String.Index>
+  }
+}

--- a/Sources/Textual/Internal/MarkdownParser/LinkedImageProcessor.swift
+++ b/Sources/Textual/Internal/MarkdownParser/LinkedImageProcessor.swift
@@ -4,6 +4,12 @@ import Foundation
 // images disappear entirely, and non-empty alt text keeps only the outer link. This processor
 // works around that by rewriting linked images into ordinary image Markdown before parsing, then
 // restoring the parsed image run with the outer link attached.
+//
+// During preprocessing, each linked image is replaced with a plain image whose alt text is a
+// private sentinel token, for example `[![](image.png)](link)` becomes
+// `![sentinel](image.png)`. Foundation can parse that into an image run, so restoration scans for
+// runs whose text matches a sentinel, replaces the sentinel with the original alt text or U+FFFC,
+// keeps the parsed image attributes, and sets `link` to the original outer destination.
 struct LinkedImageProcessor {
   private let baseURL: URL?
 

--- a/Sources/Textual/MarkdownParser/AttributedStringMarkdownParser.swift
+++ b/Sources/Textual/MarkdownParser/AttributedStringMarkdownParser.swift
@@ -23,14 +23,18 @@ public struct AttributedStringMarkdownParser: MarkupParser {
   }
 
   public func attributedString(for input: String) throws -> AttributedString {
-    try processor.expand(
+    let linkedImages = LinkedImageProcessor(baseURL: baseURL)
+    let preprocessed = linkedImages.preprocess(input)
+    let attributedString = try processor.expand(
       AttributedString(
-        markdown: input,
+        markdown: preprocessed.markdown,
         including: \.textual,
         options: options,
         baseURL: baseURL
       )
     )
+
+    return linkedImages.restore(attributedString, from: preprocessed)
   }
 }
 

--- a/Tests/TextualTests/Internal/MarkdownParser/AttributedStringMarkdownParserTests.swift
+++ b/Tests/TextualTests/Internal/MarkdownParser/AttributedStringMarkdownParserTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+
+@testable import Textual
+
+extension AttributedStringMarkdownParser {
+  @MainActor
+  struct ParserTests {
+    @Test func parsesLinkedImage() throws {
+      let parser = AttributedStringMarkdownParser(baseURL: nil)
+
+      let output = try parser.attributedString(
+        for: "[![](https://example.com/a.png)](https://example.com/b.png)"
+      )
+
+      let run = try #require(output.runs.first)
+      #expect(String(output.characters[...]) == "\u{FFFC}")
+      #expect(run.imageURL == URL(string: "https://example.com/a.png"))
+      #expect(run.link == URL(string: "https://example.com/b.png"))
+    }
+
+    @Test func parsesLinkedImageWithAltText() throws {
+      let parser = AttributedStringMarkdownParser(baseURL: nil)
+
+      let output = try parser.attributedString(
+        for: "[![Alt](https://example.com/a.png)](https://example.com/b.png)"
+      )
+
+      let run = try #require(output.runs.first)
+      #expect(String(output.characters[...]) == "Alt")
+      #expect(run.imageURL == URL(string: "https://example.com/a.png"))
+      #expect(run.link == URL(string: "https://example.com/b.png"))
+    }
+
+    @Test func preservesTextAroundLinkedImage() throws {
+      let parser = AttributedStringMarkdownParser(baseURL: nil)
+
+      let output = try parser.attributedString(
+        for: "before [![](https://example.com/a.png)](https://example.com/b.png) after"
+      )
+
+      let imageRun = try #require(output.runs.first { $0.imageURL != nil })
+      #expect(String(output.characters[...]) == "before \u{FFFC} after")
+      #expect(imageRun.imageURL == URL(string: "https://example.com/a.png"))
+      #expect(imageRun.link == URL(string: "https://example.com/b.png"))
+    }
+
+    @Test func resolvesLinkedImageRelativeURLs() throws {
+      let parser = AttributedStringMarkdownParser(
+        baseURL: URL(string: "https://example.com/repo/")!
+      )
+
+      let output = try parser.attributedString(for: "[![](assets/a.png)](docs/b)")
+
+      let run = try #require(output.runs.first)
+      #expect(
+        run.imageURL?.absoluteURL == URL(string: "https://example.com/repo/assets/a.png")
+      )
+      #expect(run.link?.absoluteURL == URL(string: "https://example.com/repo/docs/b"))
+    }
+
+    @Test func ignoresLinkedImageInInlineCode() throws {
+      let parser = AttributedStringMarkdownParser(baseURL: nil)
+
+      let output = try parser.attributedString(
+        for: "`[![](https://example.com/a.png)](https://example.com/b.png)`"
+      )
+
+      let run = try #require(output.runs.first)
+      #expect(
+        String(output.characters[...])
+          == "[![](https://example.com/a.png)](https://example.com/b.png)"
+      )
+      #expect(run.imageURL == nil)
+      #expect(run.link == nil)
+    }
+
+    @Test func ignoresLinkedImageInCodeBlock() throws {
+      let parser = AttributedStringMarkdownParser(baseURL: nil)
+
+      let output = try parser.attributedString(
+        for: """
+          ```
+          [![](https://example.com/a.png)](https://example.com/b.png)
+          ```
+          """
+      )
+
+      #expect(output.runs.allSatisfy { $0.imageURL == nil && $0.link == nil })
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Work around Foundation Markdown parsing dropping linked images like `[![](image)](link)`.
- Preserve parsed image runs and attach the outer link to the same run.
- Add coverage for empty alt text, alt text, surrounding text, relative URLs, and code blocks/spans.

Fixes #53

## Validation
- `swift test --filter AttributedStringMarkdownParser`

This screenshot shows a markdown string containing `[![](image)](link)`
```
[Automatic compute unit selection](https://developer.apple.com/videos/play/wwdc2022/10027) dispatches operations to the best unit based on support and cost.

[![Non-uniform lowering of precision using clustering](https://substackcdn.com/image/fetch/$s_!webq!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F70480806-8eb9-4085-a6fd-550361686e6f_1730x654.png "Non-uniform lowering of precision using clustering")](https://substackcdn.com/image/fetch/$s_!webq!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F70480806-8eb9-4085-a6fd-550361686e6f_1730x654.png)
```

<img width="661" height="359" alt="image" src="https://github.com/user-attachments/assets/f9dc8dfd-e26a-44d5-8fdb-2653a53ffe13" />
