### PR TITLE
Avoid stack overflow when rendering text with many attributed runs

### DIFF
--- a/Sources/Textual/Internal/TextFragment/TextBuilder.swift
+++ b/Sources/Textual/Internal/TextFragment/TextBuilder.swift
@@ -96,9 +96,12 @@ extension Text {
       return text
     }
 
-    self = textValues.reduce(Text(verbatim: "")) { partialResult, text in
-      Text("\(partialResult)\(text)")
-    }
+    // Concatenate via `Text + Text` rather than `Text("\(partialResult)\(text)")`.
+    // The interpolation form produces a `LocalizedStringKey`-backed `Text` at every
+    // reduce step; resolving the resulting N-deep chain recurses ~8 stack frames per
+    // level during SwiftUI's render pass and overflows the main-thread stack for
+    // content that produces a few hundred attributed runs (e.g. emoji-dense notes).
+    self = textValues.reduce(Text(verbatim: ""), +)
   }
 
   private init(placeholderSize size: CGSize) {


### PR DESCRIPTION
`TextBuilder` reduced the per-run `Text` values via `Text("\(partialResult)\(text)")`, wrapping every run in a `LocalizedStringKey`-backed `Text`. SwiftUI's `LocalizedStringKey.resolve` walks that chain at render time and recurses ~8 stack frames per nesting level, overflowing the main-thread stack for content that produces a few hundred runs (emoji-dense notes are an easy trigger — each emoji becomes its own run). Switching to `Text + Text` produces concat storage that resolves linearly.

No regression test included: the crash only manifests inside SwiftUI's render pass on the main thread, which `swift test` doesn't exercise; a "construct 500-run `Text` and don't crash" test would either pass trivially (no render) or take the test runner down with it (if regressed). Happy to add one if you have a pattern in mind.

Fixes #56