### PR TITLE
Mark TextualNamespace as @frozen for library-evolution support

### DIFF
--- a/Sources/Textual/TextualNamespace.swift
+++ b/Sources/Textual/TextualNamespace.swift
@@ -17,6 +17,7 @@ import Foundation
 ///
 /// SwiftUI views get the namespace through the ``SwiftUICore/View/textual`` property.
 /// Other types can opt into it by conforming to ``TextualCompatible``.
+@frozen
 public struct TextualNamespace<Base> {
   @usableFromInline let base: Base
   @inlinable public init(_ base: Base) { self.base = base }


### PR DESCRIPTION
## Summary

`TextualNamespace<Base>` currently fails to compile when consumed by a module built with `-enable-library-evolution` (e.g. an `xcframework` produced with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`):

```
TextualNamespace.swift:22:47: error: 'let' property 'base' may not be initialized directly; use "self.init(...)" or "self = ..." instead
  @inlinable public init(_ base: Base) { self.base = base }
                                              ^
```

Under library evolution, stored-property layout is resilient — so an `@inlinable` initializer can't directly assign to `let` properties (its body would be inlined into callers that don't know the property's final offset).

The fix is one keyword: marking `TextualNamespace` as `@frozen`. This is the idiomatic Swift solution for a transparent single-property wrapper struct (the same pattern used by `Binding`, `Environment`, etc. in SwiftUI). It freezes the struct's layout — which is sound here because the type is, by construction, never going to grow beyond its single `base` wrapper — and lets `@inlinable` initializers stay inlinable across library boundaries.

## Why this matters

Without this change, any project that needs to ship Textual inside a library-evolution-enabled binary framework (the standard way to distribute Swift libraries as `.xcframework` for closed-source consumers, plugins, or stable ABI surfaces) is blocked at compile time. We hit this trying to consume Textual from a UI library that ships as a stable-ABI `xcframework` to a fleet of plugin authors.

## Risk

- `@frozen` is an ABI commitment, but Textual is currently pre-1.0 and the type is by definition a single-property wrapper. There is no scenario where a future version benefits from adding stored properties to `TextualNamespace` — anything new would belong on `TextualCompatible`-conforming types or as extension methods on the namespace.
- No behavior change. No existing call sites need to update.

## Test plan

- [x] Existing test suite passes locally
- [x] Verified the offending consumer (an `xcframework` build with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`) now compiles and links cleanly
- [x] Non-library-evolution consumers continue to build with no diff
