### PR TITLE
override mouseDownCanMoveWindow for NSTextInteractionView

### DIFF
--- a/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
@@ -17,6 +17,7 @@
 
     override var acceptsFirstResponder: Bool { true }
     override var isFlipped: Bool { true }
+    override var mouseDownCanMoveWindow: Bool { false }
 
     private var dragStart: TextPosition?
     private var selectionAnchor: TextPosition?


### PR DESCRIPTION
This PR adds `mouseDownCanMoveWindow` override to `false` for `NSTextInteractionView`.

According to [docs](https://developer.apple.com/documentation/appkit/nsview/mousedowncanmovewindow) this property is set to false for opaque views, but  `NSTextInteractionView` is transparent overlay over actual text and value is set to true for it.

This does not seems right as we have actual opaque text under it that should be selectable, but without this override drag gesture is passed down to window and window is moved when user tries to select text by mouse drag.

Please correct me if I am missing something here.