### PR TITLE
Fix TextBuilder stack overflow with many attributed runs

### DIFF
--- a/Sources/Textual/Internal/TextFragment/TextBuilder.swift
+++ b/Sources/Textual/Internal/TextFragment/TextBuilder.swift
@@ -97,7 +97,7 @@ extension Text {
     }
 
     self = textValues.reduce(Text(verbatim: "")) { partialResult, text in
-      Text("\(partialResult)\(text)")
+      partialResult + text
     }
   }
 

--- a/Tests/TextualTests/Internal/TextFragment/TextBuilderTests.swift
+++ b/Tests/TextualTests/Internal/TextFragment/TextBuilderTests.swift
@@ -1,0 +1,29 @@
+#if os(macOS)
+  import SwiftUI
+  import Testing
+
+  @testable import Textual
+
+  @MainActor
+  struct TextBuilderTests {
+    @Test func renderingManyAttributedRunsDoesNotOverflowStack() {
+      let renderer = ImageRenderer(
+        content: TextFragment(Self.attributedStringWithManyRuns(count: 2_500))
+          .frame(width: 320)
+          .fixedSize(horizontal: false, vertical: true)
+          .coordinateSpace(.textContainer)
+      )
+      renderer.proposedSize = .init(width: 320, height: 4_000)
+
+      #expect(renderer.nsImage != nil)
+    }
+
+    private static func attributedStringWithManyRuns(count: Int) -> AttributedString {
+      (0..<count).reduce(into: AttributedString()) { result, index in
+        var fragment = AttributedString(index.isMultiple(of: 40) ? "\n" : "x")
+        fragment.font = index.isMultiple(of: 2) ? .body.bold() : .body
+        result += fragment
+      }
+    }
+  }
+#endif


### PR DESCRIPTION
## Summary

- Concatenate `Text` fragments with `partialResult + text` instead of localized interpolation
- Add a macOS regression test that renders 2,500 attributed runs and forces SwiftUI text resolution

This avoids building a recursively nested `LocalizedStringKey`/`Text` interpolation tree when `TextBuilder` combines many attributed runs.

Fixes #64.

## Testing

- `swift test --filter TextBuilderTests`
- `swift test --skip CodeTokenizerTests`

I also ran unfiltered `swift test`; it built successfully but my local run failed in the existing `CodeTokenizerTests` because the tokenizer was `nil`, unrelated to this change.
