### PR TITLE
Fix CI workflows and test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ concurrency:
 jobs:
   test:
     name: Test All Platforms
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 26.0
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+      - name: Select Xcode 26.5
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app
       - name: Skip macro validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Run tests
@@ -44,11 +44,11 @@ jobs:
 
   build-demo:
     name: Build TextualDemo
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 26.0
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+      - name: Select Xcode 26.5
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app
       - name: Skip macro validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
       - name: Build demo

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,13 +12,13 @@ concurrency:
 jobs:
   swift_format:
     name: swift-format
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v5
-      - name: Select Xcode 26.0
-        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+      - name: Select Xcode 26.5
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app
       - name: Format
         run: make format
       - uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,15 +13,15 @@ jobs:
   swift_format:
     name: swift-format
     runs-on: macos-15
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Select Xcode 26.0
         run: sudo xcode-select -s /Applications/Xcode_26.0.app
       - name: Format
         run: make format
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Run swift-format
           branch: main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -10,17 +10,22 @@ VISIONOS_SIMULATOR = $(call udid_for,$(VISIONOS_DEVICE))
 
 PLATFORM_IOS = iOS Simulator,id=$(IOS_SIMULATOR)
 PLATFORM_MACOS = macOS
+PLATFORM_MAC_CATALYST = macOS,variant=Mac Catalyst
 PLATFORM_TVOS = tvOS Simulator,id=$(TVOS_SIMULATOR)
 PLATFORM_WATCHOS = watchOS Simulator,id=$(WATCHOS_SIMULATOR)
 PLATFORM_VISIONOS = visionOS Simulator,id=$(VISIONOS_SIMULATOR)
 
 default: test
 
-test: test-macos test-ios test-tvos test-watchos test-visionos
+test: test-macos test-maccatalyst test-ios test-tvos test-watchos test-visionos
 
 test-macos:
 	@echo "Testing macOS..."
 	xcodebuild test -scheme Textual -destination platform="$(PLATFORM_MACOS)"
+
+test-maccatalyst:
+	@echo "Testing Mac Catalyst..."
+	xcodebuild test -scheme Textual -destination platform="$(PLATFORM_MAC_CATALYST)"
 
 test-ios:
 	@echo "Testing iOS..."
@@ -60,7 +65,7 @@ build-demo:
 	@echo "Building TextualDemo for macOS..."
 	xcodebuild build -workspace Textual.xcworkspace -scheme TextualDemo -destination platform="$(PLATFORM_MACOS)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
-.PHONY: format test bundle-prism build-demo
+.PHONY: format test test-macos test-maccatalyst test-ios test-tvos test-watchos test-visionos bundle-prism build-demo
 
 define udid_for
 $(shell xcrun simctl list --json devices available '$(1)' | jq -r '[.devices | to_entries | sort_by(.key) | reverse | .[].value | select(length > 0) | .[0]][0].udid // empty')

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
-IOS_VERSION = 26.0
-TVOS_VERSION = 26.0
-WATCHOS_VERSION = 26.0
-VISIONOS_VERSION = 26.0
+IOS_DEVICE = iPhone
+TVOS_DEVICE = TV
+WATCHOS_DEVICE = Watch
+VISIONOS_DEVICE = Vision
 
-PLATFORM_IOS = iOS Simulator,id=$(call udid_for,iOS $(IOS_VERSION),iPhone \d\+ Pro [^M])
+IOS_SIMULATOR = $(call udid_for,$(IOS_DEVICE))
+TVOS_SIMULATOR = $(call udid_for,$(TVOS_DEVICE))
+WATCHOS_SIMULATOR = $(call udid_for,$(WATCHOS_DEVICE))
+VISIONOS_SIMULATOR = $(call udid_for,$(VISIONOS_DEVICE))
+
+PLATFORM_IOS = iOS Simulator,id=$(IOS_SIMULATOR)
 PLATFORM_MACOS = macOS
-PLATFORM_TVOS = tvOS Simulator,id=$(call udid_for,tvOS $(TVOS_VERSION),TV)
-PLATFORM_WATCHOS = watchOS Simulator,id=$(call udid_for,watchOS $(WATCHOS_VERSION),Watch)
-PLATFORM_VISIONOS = visionOS Simulator,id=$(call udid_for,visionOS $(VISIONOS_VERSION),Vision)
+PLATFORM_TVOS = tvOS Simulator,id=$(TVOS_SIMULATOR)
+PLATFORM_WATCHOS = watchOS Simulator,id=$(WATCHOS_SIMULATOR)
+PLATFORM_VISIONOS = visionOS Simulator,id=$(VISIONOS_SIMULATOR)
 
 default: test
 
@@ -18,19 +23,23 @@ test-macos:
 	xcodebuild test -scheme Textual -destination platform="$(PLATFORM_MACOS)"
 
 test-ios:
-	@echo "Testing iOS $(IOS_VERSION)..."
+	@echo "Testing iOS..."
+	$(call require_simulator,$(IOS_SIMULATOR),$(IOS_DEVICE))
 	xcodebuild test -scheme Textual -destination platform="$(PLATFORM_IOS)"
 
 test-tvos:
-	@echo "Testing tvOS $(TVOS_VERSION)..."
+	@echo "Testing tvOS..."
+	$(call require_simulator,$(TVOS_SIMULATOR),$(TVOS_DEVICE))
 	xcodebuild test -scheme Textual -destination platform="$(PLATFORM_TVOS)"
 
 test-watchos:
-	@echo "Testing watchOS $(WATCHOS_VERSION)..."
+	@echo "Testing watchOS..."
+	$(call require_simulator,$(WATCHOS_SIMULATOR),$(WATCHOS_DEVICE))
 	xcodebuild test -scheme Textual -destination platform="$(PLATFORM_WATCHOS)"
 
 test-visionos:
-	@echo "Testing visionOS $(PLATFORM_VISIONOS)..."
+	@echo "Testing visionOS..."
+	$(call require_simulator,$(VISIONOS_SIMULATOR),$(VISIONOS_DEVICE))
 	xcodebuild test -scheme Textual -destination platform="$(PLATFORM_VISIONOS)"
 
 format:
@@ -54,5 +63,9 @@ build-demo:
 .PHONY: format test bundle-prism build-demo
 
 define udid_for
-$(shell xcrun simctl list devices available '$(1)' | grep '$(2)' | sort -r | head -1 | awk -F '[()]' '{ print $$(NF-3) }')
+$(shell xcrun simctl list --json devices available '$(1)' | jq -r '[.devices | to_entries | sort_by(.key) | reverse | .[].value | select(length > 0) | .[0]][0].udid // empty')
+endef
+
+define require_simulator
+@test "$(1)" != "" || (echo "No available simulator found matching '$(2)'" >&2; exit 1)
 endef

--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,12 @@ let package = Package(
         .process("Internal/Highlighter/Prism")
       ],
       swiftSettings: [
-        .define("TEXTUAL_ENABLE_LINKS", .when(platforms: [.macOS, .macCatalyst, .iOS, .watchOS, .visionOS])),
-        .define("TEXTUAL_ENABLE_TEXT_SELECTION", .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS])),
+        .define(
+          "TEXTUAL_ENABLE_LINKS",
+          .when(platforms: [.macOS, .macCatalyst, .iOS, .watchOS, .visionOS])),
+        .define(
+          "TEXTUAL_ENABLE_TEXT_SELECTION",
+          .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS])),
       ]
     ),
     .testTarget(
@@ -46,7 +50,9 @@ let package = Package(
       ],
       resources: [.copy("Fixtures")],
       swiftSettings: [
-        .define("TEXTUAL_ENABLE_TEXT_SELECTION", .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS]))
+        .define(
+          "TEXTUAL_ENABLE_TEXT_SELECTION",
+          .when(platforms: [.macOS, .macCatalyst, .iOS, .visionOS]))
       ]
     ),
   ]

--- a/Tests/TextualTests/Helpers/Snapshotting+TextLayoutCollection.swift
+++ b/Tests/TextualTests/Helpers/Snapshotting+TextLayoutCollection.swift
@@ -1,4 +1,4 @@
-#if TEXTUAL_ENABLE_TEXT_SELECTION && os(iOS)
+#if TEXTUAL_ENABLE_TEXT_SELECTION && os(iOS) && !targetEnvironment(macCatalyst)
   import SnapshotTesting
   import SwiftUI
 

--- a/Tests/TextualTests/Helpers/Snapshotting+TextualImage.swift
+++ b/Tests/TextualTests/Helpers/Snapshotting+TextualImage.swift
@@ -1,0 +1,15 @@
+#if os(iOS)
+  import SnapshotTesting
+  import SwiftUI
+
+  extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
+    @MainActor
+    static func textualImage(layout: SwiftUISnapshotLayout) -> Snapshotting {
+      .image(
+        precision: 0.995,
+        perceptualPrecision: 0.98,
+        layout: layout
+      )
+    }
+  }
+#endif

--- a/Tests/TextualTests/Helpers/Snapshotting+TextualImage.swift
+++ b/Tests/TextualTests/Helpers/Snapshotting+TextualImage.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SnapshotTesting
   import SwiftUI
 

--- a/Tests/TextualTests/Helpers/TextSelectionModel+Fixture.swift
+++ b/Tests/TextualTests/Helpers/TextSelectionModel+Fixture.swift
@@ -17,7 +17,7 @@
     }
   }
 
-  #if os(iOS)
+  #if os(iOS) && !targetEnvironment(macCatalyst)
     extension TextSelectionModel {
       @MainActor static func recordFixture<Content: View>(
         for content: Content,

--- a/Tests/TextualTests/Internal/TextInteraction/TextLayoutCollectionTests.swift
+++ b/Tests/TextualTests/Internal/TextInteraction/TextLayoutCollectionTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SwiftUI
   import Testing
   import SnapshotTesting

--- a/Tests/TextualTests/Internal/TextInteraction/TextSelectionModelTests+macOS.swift
+++ b/Tests/TextualTests/Internal/TextInteraction/TextSelectionModelTests+macOS.swift
@@ -1,4 +1,4 @@
-#if TEXTUAL_ENABLE_TEXT_SELECTION
+#if TEXTUAL_ENABLE_TEXT_SELECTION && !targetEnvironment(macCatalyst)
   import Foundation
   import SwiftUI
   import Testing

--- a/Tests/TextualTests/Internal/TextInteraction/TextSelectionModelTests.swift
+++ b/Tests/TextualTests/Internal/TextInteraction/TextSelectionModelTests.swift
@@ -1,4 +1,4 @@
-#if TEXTUAL_ENABLE_TEXT_SELECTION
+#if TEXTUAL_ENABLE_TEXT_SELECTION && !targetEnvironment(macCatalyst)
   import Foundation
   import SwiftUI
   import Testing

--- a/Tests/TextualTests/StructuredText/BlockQuoteTests.swift
+++ b/Tests/TextualTests/StructuredText/BlockQuoteTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SwiftUI
   import Testing
   import SnapshotTesting

--- a/Tests/TextualTests/StructuredText/BlockQuoteTests.swift
+++ b/Tests/TextualTests/StructuredText/BlockQuoteTests.swift
@@ -51,7 +51,7 @@
         .background(Color.guide)
         .padding(.horizontal)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
 
       @Test func indentationLevel() {
@@ -78,7 +78,7 @@
         .padding(.horizontal)
         .textual.blockQuoteStyle(IndentationLevelBlockQuoteStyle(colors: .green, .mint, .teal))
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
     }
   }

--- a/Tests/TextualTests/StructuredText/CodeBlockTests.swift
+++ b/Tests/TextualTests/StructuredText/CodeBlockTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SwiftUI
   import Testing
   import SnapshotTesting

--- a/Tests/TextualTests/StructuredText/CodeBlockTests.swift
+++ b/Tests/TextualTests/StructuredText/CodeBlockTests.swift
@@ -29,7 +29,7 @@
         )
         .padding(.horizontal)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
     }
   }

--- a/Tests/TextualTests/StructuredText/HeadingTests.swift
+++ b/Tests/TextualTests/StructuredText/HeadingTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SwiftUI
   import Testing
   import SnapshotTesting

--- a/Tests/TextualTests/StructuredText/HeadingTests.swift
+++ b/Tests/TextualTests/StructuredText/HeadingTests.swift
@@ -29,7 +29,7 @@
         )
         .background(Color.guide)
         .padding(.horizontal)
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
 
       @Test func inlines() {
@@ -43,7 +43,7 @@
         )
         .background(Color.guide)
         .padding(.horizontal)
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
     }
   }

--- a/Tests/TextualTests/StructuredText/MathExpressionTests.swift
+++ b/Tests/TextualTests/StructuredText/MathExpressionTests.swift
@@ -26,7 +26,7 @@
         .background(Color.guide)
         .padding(.horizontal)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
 
       @Test func mathBlockAlignment() {
@@ -45,7 +45,7 @@
         .multilineTextAlignment(.leading)
         .textual.mathProperties(.init(textAlignment: .trailing))
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
     }
   }

--- a/Tests/TextualTests/StructuredText/MathExpressionTests.swift
+++ b/Tests/TextualTests/StructuredText/MathExpressionTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SnapshotTesting
   import SwiftUI
   import Testing

--- a/Tests/TextualTests/StructuredText/OrderedListTests.swift
+++ b/Tests/TextualTests/StructuredText/OrderedListTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SwiftUI
   import Testing
   import SnapshotTesting

--- a/Tests/TextualTests/StructuredText/OrderedListTests.swift
+++ b/Tests/TextualTests/StructuredText/OrderedListTests.swift
@@ -59,7 +59,7 @@
         .padding(.horizontal)
         .textual.orderedListMarker(.lowerRoman)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
 
       @Test func upperRomanList() {
@@ -81,7 +81,7 @@
         .padding(.horizontal)
         .textual.orderedListMarker(.upperRoman)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
 
       @Test func lowerAlphaList() {
@@ -103,7 +103,7 @@
         .padding(.horizontal)
         .textual.orderedListMarker(.lowerAlpha)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
 
       @Test func upperAlphaList() {
@@ -125,7 +125,7 @@
         .padding(.horizontal)
         .textual.orderedListMarker(.upperAlpha)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
     }
   }

--- a/Tests/TextualTests/StructuredText/TableTests.swift
+++ b/Tests/TextualTests/StructuredText/TableTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SwiftUI
   import Testing
   import SnapshotTesting

--- a/Tests/TextualTests/StructuredText/TableTests.swift
+++ b/Tests/TextualTests/StructuredText/TableTests.swift
@@ -25,7 +25,7 @@
         )
         .padding(.horizontal)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
 
       @Test func tableAlignment() {
@@ -43,7 +43,7 @@
         )
         .padding(.horizontal)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
     }
   }

--- a/Tests/TextualTests/StructuredText/ThematicBreakTests.swift
+++ b/Tests/TextualTests/StructuredText/ThematicBreakTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SwiftUI
   import Testing
   import SnapshotTesting

--- a/Tests/TextualTests/StructuredText/ThematicBreakTests.swift
+++ b/Tests/TextualTests/StructuredText/ThematicBreakTests.swift
@@ -33,7 +33,7 @@
         .background(Color.guide)
         .padding(.horizontal)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
     }
   }

--- a/Tests/TextualTests/StructuredText/UnorderedListTests.swift
+++ b/Tests/TextualTests/StructuredText/UnorderedListTests.swift
@@ -1,4 +1,4 @@
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import SwiftUI
   import Testing
   import SnapshotTesting

--- a/Tests/TextualTests/StructuredText/UnorderedListTests.swift
+++ b/Tests/TextualTests/StructuredText/UnorderedListTests.swift
@@ -25,7 +25,7 @@
         .padding(.horizontal)
         .textual.unorderedListMarker(.hierarchical(.disc, .circle, .square))
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
 
       @Test func dashList() {
@@ -43,7 +43,7 @@
         .padding(.horizontal)
         .textual.unorderedListMarker(.dash)
 
-        assertSnapshot(of: view, as: .image(layout: layout))
+        assertSnapshot(of: view, as: .textualImage(layout: layout))
       }
     }
   }


### PR DESCRIPTION
This PR gets CI back into shape after adding Catalyst support. It fixes the format workflow, lets the test matrix pick the newest available simulators, and adds Mac Catalyst to `make test`. It also gives the iOS snapshot tests a small tolerance for harmless rendering changes.