### PR TITLE
Fix state-during-view-update faults in text selection

### DIFF
--- a/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextSelectionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextSelectionView.swift
@@ -11,7 +11,6 @@
 
   struct AppKitTextSelectionView: View {
     @Environment(TextSelectionModel.self) private var textSelectionModel: TextSelectionModel?
-    @State private var selectionRects: [TextSelectionRect] = []
 
     private let layout: Text.Layout
     private let origin: CGPoint
@@ -22,7 +21,8 @@
     }
 
     var body: some View {
-      Group {
+      let selectionRects = self.selectionRects
+      return Group {
         if selectionRects.isEmpty {
           Color.clear
         } else {
@@ -37,18 +37,22 @@
           }
         }
       }
-      .onChange(of: textSelectionModel?.selectedRange, initial: true, updateSelectionRects)
-      .onChange(of: layout, initial: true, updateSelectionRects)
     }
 
-    private func updateSelectionRects() {
-      if let textSelectionModel,
-        let selectedRange = textSelectionModel.selectedRange
-      {
-        selectionRects = textSelectionModel.selectionRects(for: selectedRange, layout: layout)
-      } else {
-        selectionRects = []
+    /// Selection rectangles for the current range within this layout.
+    ///
+    /// Derived in `body` rather than stored in `@State` and seeded from an
+    /// `onChange(initial: true)`: that initial action wrote state during the first
+    /// view update, which SwiftUI flags ("Modifying state during view update", and
+    /// previously "tried to update multiple times per frame" when both the
+    /// `selectedRange` and `layout` handlers fired on the same frame). As an
+    /// `@Observable`-tracked computation it still recomputes whenever the selected
+    /// range or `layout` changes, with no state mutation.
+    private var selectionRects: [TextSelectionRect] {
+      guard let textSelectionModel, let selectedRange = textSelectionModel.selectedRange else {
+        return []
       }
+      return textSelectionModel.selectionRects(for: selectedRange, layout: layout)
     }
   }
 #endif

--- a/Sources/Textual/Internal/TextInteraction/Shared/TextSelectionModel.swift
+++ b/Sources/Textual/Internal/TextInteraction/Shared/TextSelectionModel.swift
@@ -60,11 +60,18 @@
         return
       }
 
-      // Try to reconcile the selected text range
-      self.selectedRange = layoutCollection.reconcileRange(
+      // Try to reconcile the selected text range. Only write when it actually
+      // changes: as the overlay's GeometryReader/preferences converge, this runs
+      // several times per frame with the same result, and a redundant write to the
+      // observed `selectedRange` is what SwiftUI flags as "onChange(of:
+      // AnyTextLayoutCollection) action tried to update multiple times per frame".
+      let reconciled = layoutCollection.reconcileRange(
         selectedRange,
         from: oldLayoutCollection
       )
+      if reconciled != self.selectedRange {
+        self.selectedRange = reconciled
+      }
     }
 
     func setCoordinator(_ coordinator: TextSelectionCoordinator?) {


### PR DESCRIPTION
## Problem

Fixes #22.

With text selection enabled (`.textual.textSelection(.enabled)`), SwiftUI logs non-fatal faults on layout passes. The issue reports the iOS `AnyTextLayoutCollection` message; on macOS there's additionally an `onChange(of: Layout)` variant and — once the duplicate handler is removed — a `Modifying state during view update` fault. All stem from the selection layer writing observed/`@State` values during a view update.

## Changes

**`AppKitTextSelectionView`** stored selection rectangles in `@State` and seeded them from two `onChange(initial: true)` handlers (one on `selectedRange`, one on `layout`), both writing the same state during the initial view update — two writes in one frame (`multiple times per frame`), and a single surviving write still during the update (`Modifying state during view update`). This derives the rectangles as an `@Observable`-tracked computed property instead:

```swift
private var selectionRects: [TextSelectionRect] {
  guard let textSelectionModel, let selectedRange = textSelectionModel.selectedRange else { return [] }
  return textSelectionModel.selectionRects(for: selectedRange, layout: layout)
}
```

No `@State`, no `onChange`, no state mutation during the update. It still recomputes whenever the selected range or `layout` changes (the read of `selectedRange` is tracked by Observation), so selection rendering is unchanged.

**`TextSelectionModel.setLayoutCollection`** re-wrote the observed `selectedRange` during reconciliation even when the reconciled value was unchanged. As the overlay's `GeometryReader`/preferences converge this runs several times per frame, and the redundant write to the observed property is what trips the `AnyTextLayoutCollection` diagnostic. It now only assigns when the value actually changes.

## Testing

- `Textual` target builds cleanly (`xcodebuild -scheme Textual -destination 'platform=macOS'` → BUILD SUCCEEDED).
- Verified in a consuming macOS app (markdown rendered via `StructuredText(markdown:).textual.textSelection(.enabled)`): **all three faults are gone** from the console — both at launch and during interaction — with selection highlighting still rendering and reconciling correctly across layout/selection changes. The earlier handler-merge revision removed the two `... multiple times per frame` faults but surfaced `Modifying state during view update`; the computed-property approach in this PR removes that last one as well.

I didn't find an existing harness for exercising the SwiftUI selection layout in tests — happy to add coverage if you can point me at the preferred approach for these view-level interactions.