### PR TITLE
Clear iOS text selection after resigning focus

### DIFF
--- a/Sources/Textual/Internal/TextInteraction/UIKit/UITextInteractionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/UIKit/UITextInteractionView.swift
@@ -17,6 +17,14 @@
       true
     }
 
+    override func resignFirstResponder() -> Bool {
+      let didResign = super.resignFirstResponder()
+      if didResign {
+        model.selectedRange = nil
+      }
+      return didResign
+    }
+
     var model: TextSelectionModel
     var exclusionRects: [CGRect]
     var openURL: OpenURLAction

--- a/Tests/TextualTests/Internal/TextInteraction/UITextInteractionViewTests.swift
+++ b/Tests/TextualTests/Internal/TextInteraction/UITextInteractionViewTests.swift
@@ -1,0 +1,37 @@
+#if TEXTUAL_ENABLE_TEXT_SELECTION && os(iOS) && !targetEnvironment(macCatalyst)
+  import SwiftUI
+  import Testing
+  import UIKit
+
+  @testable import Textual
+
+  @MainActor
+  struct UITextInteractionViewTests {
+    @Test
+    func resignFirstResponderClearsSelection() throws {
+      let model = try TextSelectionModel(fixtureName: "two-paragraphs-bidi")
+      model.selectedRange = TextRange(start: model.startPosition, end: model.endPosition)
+
+      let view = UITextInteractionView(
+        model: model,
+        exclusionRects: [],
+        openURL: OpenURLAction { _ in .discarded }
+      )
+
+      let window = UIWindow(frame: UIScreen.main.bounds)
+      let viewController = UIViewController()
+      viewController.view.addSubview(view)
+      window.rootViewController = viewController
+      window.makeKeyAndVisible()
+      defer { window.isHidden = true }
+
+      #expect(model.selectedRange != nil)
+      #expect(view.becomeFirstResponder())
+
+      let didResign = view.resignFirstResponder()
+
+      #expect(didResign)
+      #expect(model.selectedRange == nil)
+    }
+  }
+#endif


### PR DESCRIPTION
## Problem
On iOS, selected Textual content can remain highlighted after focus moves into another input, such as a text field or composer. Copying selected text should continue to leave the selection intact, but once the interaction view resigns first responder because another control becomes active, the stale selection should be cleared.

## Fix
This clears `model.selectedRange` from `UITextInteractionView.resignFirstResponder()` after `super.resignFirstResponder()` succeeds. That keeps copy/share behavior unchanged while tying selection cleanup to the UIKit focus lifecycle.

The change is scoped to UIKit because this issue is caused by UIKit first-responder focus changes. AppKit uses a separate selection interaction path, so this PR leaves macOS behavior unchanged.

## Validation
- `make test-ios`
