### PR TITLE
Add text selection menu actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ StructuredText(
 Scrollable regions like code blocks handle their own selection contexts. When you select text in a scrollable area,
 any document-level selection clears automatically, and vice versa.
 
+On macOS, applications can append actions to Textual's selection context menu:
+
+```swift
+StructuredText(markdown: content)
+  .textual.textSelection(.enabled)
+  .textual.textSelectionMenuAction(
+    TextSelectionMenuAction(id: "lookup", title: "Look Up") { selection in
+      lookUp(selection.text, context: selection.surroundingText)
+    }
+  )
+```
+
+The callback also receives the selection bounds in the interaction view's local coordinate space.
+
 ### Styling
 
 Textual provides a flexible styling system that lets you customize every aspect of structured text rendering. At the

--- a/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextInteractionOverlay.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/AppKitTextInteractionOverlay.swift
@@ -13,6 +13,7 @@
   struct AppKitTextInteractionOverlay: NSViewRepresentable {
     private let model: TextSelectionModel
     private let overflowFrames: [CGRect]
+    @Environment(\.textSelectionMenuActions) private var menuActions
 
     init(model: TextSelectionModel, overflowFrames: [CGRect]) {
       self.model = model
@@ -23,7 +24,8 @@
       NSTextInteractionView(
         model: model,
         exclusionRects: overflowFrames,
-        openURL: context.environment.openURL
+        openURL: context.environment.openURL,
+        menuActions: menuActions
       )
     }
 
@@ -31,6 +33,7 @@
       nsView.model = model
       nsView.exclusionRects = overflowFrames
       nsView.openURL = context.environment.openURL
+      nsView.menuActions = menuActions
     }
   }
 #endif

--- a/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
+++ b/Sources/Textual/Internal/TextInteraction/AppKit/NSTextInteractionView.swift
@@ -14,6 +14,7 @@
     var model: TextSelectionModel
     var exclusionRects: [CGRect]
     var openURL: OpenURLAction
+    var menuActions: [TextSelectionMenuAction]
 
     override var acceptsFirstResponder: Bool { true }
     override var isFlipped: Bool { true }
@@ -21,15 +22,18 @@
 
     private var dragStart: TextPosition?
     private var selectionAnchor: TextPosition?
+    private var menuActionsByID: [String: TextSelectionMenuAction] = [:]
 
     init(
       model: TextSelectionModel,
       exclusionRects: [CGRect],
-      openURL: OpenURLAction
+      openURL: OpenURLAction,
+      menuActions: [TextSelectionMenuAction]
     ) {
       self.model = model
       self.exclusionRects = exclusionRects
       self.openURL = openURL
+      self.menuActions = menuActions
 
       super.init(frame: .zero)
       self.wantsLayer = false
@@ -219,6 +223,26 @@
         )
       )
 
+      if !menuActions.isEmpty, let selection = model.menuSelection(in: selectedRange) {
+        menuActionsByID = Dictionary(
+          menuActions.map { ($0.id, $0) },
+          uniquingKeysWith: { _, latest in latest }
+        )
+        contextMenu.addItem(.separator())
+        for action in menuActions {
+          let item = NSMenuItem(
+            title: action.title(for: selection),
+            action: #selector(performSelectionMenuAction(_:)),
+            keyEquivalent: ""
+          )
+          item.target = self
+          item.representedObject = action.id
+          contextMenu.addItem(item)
+        }
+      } else {
+        menuActionsByID.removeAll()
+      }
+
       return contextMenu
     }
 
@@ -287,6 +311,17 @@
       let formatter = Formatter(attributedText)
       pasteboard.setString(formatter.plainText(), forType: .string)
       pasteboard.setString(formatter.html(), forType: .html)
+    }
+
+    @objc private func performSelectionMenuAction(_ sender: NSMenuItem) {
+      guard let id = sender.representedObject as? String,
+        let action = menuActionsByID[id],
+        let selectedRange = model.selectedRange,
+        let selection = model.menuSelection(in: selectedRange)
+      else {
+        return
+      }
+      action.perform(with: selection)
     }
   }
 

--- a/Sources/Textual/Internal/TextInteraction/Shared/TextSelectionInteraction.swift
+++ b/Sources/Textual/Internal/TextInteraction/Shared/TextSelectionInteraction.swift
@@ -46,5 +46,9 @@ struct TextSelectionInteraction: ViewModifier {
     @available(watchOS, unavailable)
     @usableFromInline
     @Entry var textSelection: any TextSelectability.Type = DisabledTextSelectability.self
+
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+      @Entry var textSelectionMenuActions: [TextSelectionMenuAction] = []
+    #endif
   }
 #endif

--- a/Sources/Textual/Internal/TextInteraction/Shared/TextSelectionModel.swift
+++ b/Sources/Textual/Internal/TextInteraction/Shared/TextSelectionModel.swift
@@ -106,6 +106,31 @@
       attributedText(in: range).string
     }
 
+    #if canImport(AppKit) && !targetEnvironment(macCatalyst)
+      func menuSelection(in range: TextRange) -> TextualTextSelection? {
+        guard !range.isCollapsed else {
+          return nil
+        }
+
+        let selectedText = text(in: range)
+        guard !selectedText.isEmpty else {
+          return nil
+        }
+
+        let surroundingText = blockRange(for: range.start).map(text(in:))
+        let rect = selectionRects(for: range)
+          .map(\.rect)
+          .reduce(into: CGRect.null) { result, rect in
+            result = result.union(rect)
+          }
+        return TextualTextSelection(
+          text: selectedText,
+          surroundingText: surroundingText,
+          selectionRect: rect
+        )
+      }
+    #endif
+
     func position(from position: TextPosition, offset: Int) -> TextPosition? {
       layoutCollection.position(from: position, offset: offset)
     }

--- a/Sources/Textual/TextSelectionMenuAction.swift
+++ b/Sources/Textual/TextSelectionMenuAction.swift
@@ -1,0 +1,63 @@
+#if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit) && !targetEnvironment(macCatalyst)
+  import CoreGraphics
+
+  /// Plain-text information passed to a custom macOS text-selection menu action.
+  public struct TextualTextSelection: Sendable {
+    /// The selected text.
+    public let text: String
+
+    /// The text block containing the selection, when one can be resolved.
+    public let surroundingText: String?
+
+    /// The selection bounds in the interaction view's local coordinate space.
+    public let selectionRect: CGRect
+
+    /// Creates a selection value supplied to a custom context-menu action.
+    public init(text: String, surroundingText: String?, selectionRect: CGRect) {
+      self.text = text
+      self.surroundingText = surroundingText
+      self.selectionRect = selectionRect
+    }
+  }
+
+  /// One application-defined action appended to Textual's macOS selection context menu.
+  public struct TextSelectionMenuAction: Identifiable, Sendable {
+    /// A stable identity used to route menu invocations.
+    public let id: String
+
+    private let makeTitle: @MainActor @Sendable (TextualTextSelection) -> String
+    private let performAction: @MainActor @Sendable (TextualTextSelection) -> Void
+
+    /// Creates an action with a fixed menu title.
+    public init(
+      id: String,
+      title: String,
+      perform: @escaping @MainActor @Sendable (TextualTextSelection) -> Void
+    ) {
+      self.id = id
+      self.makeTitle = { _ in title }
+      self.performAction = perform
+    }
+
+    /// Creates an action whose menu title is derived from the current selection.
+    public init(
+      id: String,
+      title: @escaping @MainActor @Sendable (TextualTextSelection) -> String,
+      perform: @escaping @MainActor @Sendable (TextualTextSelection) -> Void
+    ) {
+      self.id = id
+      self.makeTitle = title
+      self.performAction = perform
+    }
+
+    @MainActor
+    func title(for selection: TextualTextSelection) -> String {
+      makeTitle(selection)
+    }
+
+    @MainActor
+    func perform(with selection: TextualTextSelection) {
+      performAction(selection)
+    }
+  }
+#endif

--- a/Sources/Textual/TextualNamespace.swift
+++ b/Sources/Textual/TextualNamespace.swift
@@ -21,6 +21,12 @@ import Foundation
 public struct TextualNamespace<Base> {
   @usableFromInline let base: Base
   @inlinable public init(_ base: Base) { self.base = base }
+
+  /// The value wrapped by this namespace.
+  ///
+  /// This property lets integration packages add `.textual` APIs without requiring those APIs
+  /// to live in the Textual module.
+  @inlinable public var content: Base { base }
 }
 
 extension TextualNamespace: Sendable where Base: Sendable {}

--- a/Sources/Textual/View+Textual.swift
+++ b/Sources/Textual/View+Textual.swift
@@ -159,6 +159,22 @@ extension TextualNamespace where Base: View {
     #endif
   }
 
+  #if TEXTUAL_ENABLE_TEXT_SELECTION && canImport(AppKit) && !targetEnvironment(macCatalyst)
+    /// Appends an application-defined action to Textual's macOS selection context menu.
+    ///
+    /// The action receives the selected plain text, its containing text block when available, and
+    /// the local selection bounds. Apply ``textSelection(_:)`` separately to enable selection.
+    @available(iOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(visionOS, unavailable)
+    public func textSelectionMenuAction(_ action: TextSelectionMenuAction) -> some View {
+      base.transformEnvironment(\.textSelectionMenuActions) { actions in
+        actions.append(action)
+      }
+    }
+  #endif
+
   /// Sets the spacing used between table cells in ``StructuredText``.
   public func tableCellSpacing(
     horizontal: CGFloat? = nil,

--- a/Tests/TextualTests/Internal/TextInteraction/TextSelectionModelTests+macOS.swift
+++ b/Tests/TextualTests/Internal/TextInteraction/TextSelectionModelTests+macOS.swift
@@ -7,6 +7,26 @@
 
   extension TextSelectionModelTests {
     @Test
+    @MainActor
+    @available(iOS, unavailable)
+    @available(visionOS, unavailable)
+    func customMenuSelectionIncludesSelectedWordAndBlock() throws {
+      let model = try TextSelectionModel(fixtureName: "two-paragraphs-bidi")
+      let position = TextPosition(
+        indexPath: .init(runSlice: 2, run: 1, line: 0, layout: 0),
+        affinity: .downstream
+      )
+      let range = try #require(model.wordRange(for: position))
+
+      let selection = try #require(model.menuSelection(in: range))
+
+      #expect(selection.text == "sample")
+      #expect(selection.surroundingText?.contains("sample paragraph") == true)
+      #expect(!selection.selectionRect.isNull)
+      #expect(!selection.selectionRect.isEmpty)
+    }
+
+    @Test
     @available(iOS, unavailable)
     @available(visionOS, unavailable)
     func wordRange() throws {


### PR DESCRIPTION
## Summary

- add a scoped macOS text-selection menu extension point
- expose selected text, its containing text block, and the selection rectangle
- preserve Textual’s existing selection and copy behavior

Feel free to close this PR if this feature isn’t aligned with Textual’s roadmap.

## Validation

- `swift test --filter TextSelectionModelTests`
