### PR TITLE
Derive Content in Body so Missed `.appear` Events Cannot Blank the Text

### DIFF
--- a/Sources/Textual/InlineText/InlineText.swift
+++ b/Sources/Textual/InlineText/InlineText.swift
@@ -95,7 +95,7 @@ import SwiftUI
 ///   .textual.inlineStyle(style)
 /// ```
 public struct InlineText: View {
-  @State private var attributedString = AttributedString()
+  @State private var parseCache = MarkupParseCache()
 
   private let markup: String
   private let parser: any MarkupParser
@@ -111,16 +111,13 @@ public struct InlineText: View {
   }
 
   public var body: some View {
-    WithAttachments(attributedString) {
+    WithAttachments(parseCache.attributedString(for: markup, parser: parser)) {
       WithInlineStyle($0) {
         TextFragment($0)
           .modifier(TextSelectionInteraction())
       }
     }
     .coordinateSpace(.textContainer)
-    .onChange(of: markup, initial: true) { _, value in
-      self.attributedString = (try? parser.attributedString(for: value)) ?? .init()
-    }
   }
 }
 

--- a/Sources/Textual/Internal/MarkdownParser/PatternProcessor.swift
+++ b/Sources/Textual/Internal/MarkdownParser/PatternProcessor.swift
@@ -21,6 +21,10 @@ extension AttributedStringMarkdownParser {
       self.tokenizer = PatternTokenizer(patterns: syntaxExtensions.flatMap(\.patterns))
     }
 
+    var cacheKeys: [AnyHashable] {
+      syntaxExtensions.map(\.cacheKey)
+    }
+
     func expand(_ attributedString: AttributedString) throws -> AttributedString {
       guard !syntaxExtensions.isEmpty else {
         return attributedString

--- a/Sources/Textual/Internal/MarkupParseCache.swift
+++ b/Sources/Textual/Internal/MarkupParseCache.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Memoizes the parse of a markup string so a view can derive its content directly in `body`,
+/// instead of seeding `@State` from appear events that a lazily materialized view may never receive.
+@MainActor
+final class MarkupParseCache {
+  private var markup: String?
+  private var attributedString = AttributedString()
+
+  func attributedString(for markup: String, parser: any MarkupParser) -> AttributedString {
+    if markup != self.markup {
+      self.markup = markup
+      self.attributedString = (try? parser.attributedString(for: markup)) ?? .init()
+    }
+    return attributedString
+  }
+}

--- a/Sources/Textual/Internal/MarkupParseCache.swift
+++ b/Sources/Textual/Internal/MarkupParseCache.swift
@@ -5,11 +5,13 @@ import Foundation
 @MainActor
 final class MarkupParseCache {
   private var markup: String?
+  private var parserKey: AnyHashable?
   private var attributedString = AttributedString()
 
   func attributedString(for markup: String, parser: any MarkupParser) -> AttributedString {
-    if markup != self.markup {
+    if markup != self.markup || parser.cacheKey != parserKey {
       self.markup = markup
+      self.parserKey = parser.cacheKey
       self.attributedString = (try? parser.attributedString(for: markup)) ?? .init()
     }
     return attributedString

--- a/Sources/Textual/Internal/TextFragment/TextFragment.swift
+++ b/Sources/Textual/Internal/TextFragment/TextFragment.swift
@@ -30,14 +30,16 @@ struct TextFragment<Content: AttributedStringProtocol>: View {
   @MainActor
   final class BuilderCache {
     private var content: Content?
+    private var environment: TextEnvironmentValues?
     private var builder: TextBuilder?
 
     func builder(for content: Content, environment: TextEnvironmentValues) -> TextBuilder {
-      if let builder, content == self.content {
+      if let builder, content == self.content, environment == self.environment {
         return builder
       }
       let builder = TextBuilder(content, environment: environment)
       self.content = content
+      self.environment = environment
       self.builder = builder
       return builder
     }

--- a/Sources/Textual/Internal/TextFragment/TextFragment.swift
+++ b/Sources/Textual/Internal/TextFragment/TextFragment.swift
@@ -26,8 +26,25 @@ import SwiftUI
 // attributed content with inline attachments, links, and selection.
 
 struct TextFragment<Content: AttributedStringProtocol>: View {
+  /// Memoizes the `TextBuilder` for the current content so `body` can derive it directly.
+  @MainActor
+  final class BuilderCache {
+    private var content: Content?
+    private var builder: TextBuilder?
+
+    func builder(for content: Content, environment: TextEnvironmentValues) -> TextBuilder {
+      if let builder, content == self.content {
+        return builder
+      }
+      let builder = TextBuilder(content, environment: environment)
+      self.content = content
+      self.builder = builder
+      return builder
+    }
+  }
+
   @Environment(\.textEnvironment) private var textEnvironment
-  @State private var textBuilder: TextBuilder?
+  @State private var builderCache = BuilderCache()
 
   private let content: Content
 
@@ -36,22 +53,16 @@ struct TextFragment<Content: AttributedStringProtocol>: View {
   }
 
   var body: some View {
-    text
+    builderCache.builder(for: content, environment: textEnvironment).text
       .customAttribute(TextFragmentAttribute())
       .onGeometryChange(for: CGSize?.self, of: \.textContainerSize) { size in
-        guard let size, let textBuilder else { return }
-        textBuilder.sizeChanged(size, environment: textEnvironment)
-      }
-      .onChange(of: content, initial: true) { _, newValue in
-        self.textBuilder = TextBuilder(newValue, environment: textEnvironment)
+        guard let size else { return }
+        builderCache.builder(for: content, environment: textEnvironment)
+          .sizeChanged(size, environment: textEnvironment)
       }
       .modifier(TextSelectionBackground())
       .modifier(AttachmentOverlay(attachments: content.attachments()))
       .modifier(TextLinkInteraction())
-  }
-
-  private var text: Text {
-    textBuilder?.text ?? Text(verbatim: "")
   }
 }
 

--- a/Sources/Textual/MarkdownParser/AttributedStringMarkdownParser.swift
+++ b/Sources/Textual/MarkdownParser/AttributedStringMarkdownParser.swift
@@ -22,6 +22,28 @@ public struct AttributedStringMarkdownParser: MarkupParser {
     self.processor = PatternProcessor(syntaxExtensions: syntaxExtensions)
   }
 
+  public var cacheKey: AnyHashable {
+    Key(
+      baseURL: baseURL,
+      interpretedSyntax: options.interpretedSyntax,
+      failurePolicy: options.failurePolicy,
+      languageCode: options.languageCode,
+      allowsExtendedAttributes: options.allowsExtendedAttributes,
+      appliesSourcePositionAttributes: options.appliesSourcePositionAttributes,
+      syntaxExtensions: processor.cacheKeys
+    )
+  }
+
+  private struct Key: Hashable {
+    let baseURL: URL?
+    let interpretedSyntax: AttributedString.MarkdownParsingOptions.InterpretedSyntax
+    let failurePolicy: AttributedString.MarkdownParsingOptions.FailurePolicy
+    let languageCode: String?
+    let allowsExtendedAttributes: Bool
+    let appliesSourcePositionAttributes: Bool
+    let syntaxExtensions: [AnyHashable]
+  }
+
   public func attributedString(for input: String) throws -> AttributedString {
     try processor.expand(
       AttributedString(

--- a/Sources/Textual/MarkdownParser/SyntaxExtension.swift
+++ b/Sources/Textual/MarkdownParser/SyntaxExtension.swift
@@ -3,6 +3,8 @@ import Foundation
 extension AttributedStringMarkdownParser {
   /// A syntax extension that replaces matched tokens after Markdown parsing.
   public struct SyntaxExtension {
+    /// What the extension was made from; two extensions with the same key parse the same way.
+    let cacheKey: AnyHashable
     let patterns: [PatternTokenizer.Pattern]
     let replace:
       (
@@ -16,7 +18,7 @@ extension AttributedStringMarkdownParser.SyntaxExtension {
   /// Replaces `:shortcode:` sequences using the provided custom emoji definitions.
   public static func emoji(_ emoji: Set<Emoji>) -> Self {
     guard !emoji.isEmpty else {
-      return Self(patterns: [], replace: { _, _ in nil })
+      return Self(cacheKey: "emoji", patterns: [], replace: { _, _ in nil })
     }
 
     let emojiMap = Dictionary(
@@ -25,7 +27,7 @@ extension AttributedStringMarkdownParser.SyntaxExtension {
       }
     )
 
-    return Self(patterns: [.emoji]) { token, attributes in
+    return Self(cacheKey: "emoji:" + emoji.map(\.shortcode).sorted().joined(separator: ","), patterns: [.emoji]) { token, attributes in
       guard let shortcode = token.capturedContent, let emoji = emojiMap[shortcode] else {
         return nil
       }
@@ -39,7 +41,7 @@ extension AttributedStringMarkdownParser.SyntaxExtension {
 
   /// Replaces inline and block math expressions with attachments.
   public static var math: Self {
-    .init(patterns: [.mathBlock, .mathInline]) { token, attributes in
+    .init(cacheKey: "math", patterns: [.mathBlock, .mathInline]) { token, attributes in
       guard let latex = token.capturedContent else {
         return nil
       }

--- a/Sources/Textual/MarkupParser.swift
+++ b/Sources/Textual/MarkupParser.swift
@@ -30,9 +30,21 @@ import Foundation
 /// missing or inconsistent intents will typically show up as incorrect block rendering.
 @MainActor
 public protocol MarkupParser {
+  /// Identifies this parser's configuration, so a cached parse is reused only for the same one.
+  ///
+  /// Defaults to the parser's type. A parser with settings of its own (a base URL, options, extensions) should
+  /// fold them in, or a view that keeps its markup but changes the parser shows the previous parse.
+  var cacheKey: AnyHashable { get }
+
   /// Returns attributed content for the given input string.
   ///
   /// - Parameter input: The markup source string.
   /// - Returns: An attributed string representing the parsed markup.
   func attributedString(for input: String) throws -> AttributedString
+}
+
+extension MarkupParser {
+  public var cacheKey: AnyHashable {
+    ObjectIdentifier(Self.self)
+  }
 }

--- a/Sources/Textual/StructuredText/StructuredText.swift
+++ b/Sources/Textual/StructuredText/StructuredText.swift
@@ -102,7 +102,7 @@ import SwiftUI
 /// When you need to parse something other than Markdown, use ``init(_:parser:)`` with a custom
 /// ``MarkupParser`` implementation.
 public struct StructuredText: View {
-  @State private var attributedString = AttributedString()
+  @State private var parseCache = MarkupParseCache()
 
   private let markup: String
   private let parser: any MarkupParser
@@ -116,21 +116,14 @@ public struct StructuredText: View {
   }
 
   public var body: some View {
-    WithAttachments(attributedString) {
+    WithAttachments(parseCache.attributedString(for: markup, parser: parser)) {
       BlockContent(content: $0)
         .modifier(TextSelectionInteraction())
         .modifier(TextSelectionCoordination())
     }
     .coordinateSpace(.textContainer)
-    .onChange(of: markup, initial: true) {
-      markupDidChange(markup)
-    }
     // Disable line limit to avoid per-fragment truncation
     .lineLimit(nil)
-  }
-
-  private func markupDidChange(_ markup: String) {
-    self.attributedString = (try? parser.attributedString(for: markup)) ?? .init()
   }
 }
 

--- a/Tests/TextualTests/Internal/MarkdownParser/MarkupParseCacheTests.swift
+++ b/Tests/TextualTests/Internal/MarkdownParser/MarkupParseCacheTests.swift
@@ -1,0 +1,29 @@
+import Testing
+
+@testable import Textual
+
+@MainActor
+struct MarkupParseCacheTests {
+  @Test func reusesTheParseForTheSameMarkupAndParser() {
+    let cache = MarkupParseCache()
+    let first = cache.attributedString(for: "**bold**", parser: .markdown())
+    let second = cache.attributedString(for: "**bold**", parser: .markdown())
+    #expect(first == second)
+  }
+
+  @Test func reparsesWhenTheParserChanges() {
+    let cache = MarkupParseCache()
+    let plain = cache.attributedString(for: "$x$", parser: .markdown())
+    let math = cache.attributedString(for: "$x$", parser: .markdown(syntaxExtensions: [.math]))
+    #expect(plain != math)
+  }
+
+  @Test func parsersWithTheSameConfigurationShareAKey() {
+    #expect(AttributedStringMarkdownParser.markdown().cacheKey == AttributedStringMarkdownParser.markdown().cacheKey)
+    #expect(AttributedStringMarkdownParser.markdown().cacheKey != AttributedStringMarkdownParser.inlineMarkdown().cacheKey)
+    #expect(
+      AttributedStringMarkdownParser.markdown(syntaxExtensions: [.math]).cacheKey
+        != AttributedStringMarkdownParser.markdown().cacheKey
+    )
+  }
+}

--- a/Tests/TextualTests/Internal/TextFragment/BuilderCacheTests.swift
+++ b/Tests/TextualTests/Internal/TextFragment/BuilderCacheTests.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import Testing
+
+@testable import Textual
+
+@MainActor
+struct BuilderCacheTests {
+  @Test func reusesTheBuilderForTheSameContentAndEnvironment() {
+    let cache = TextFragment<AttributedString>.BuilderCache()
+    let environment = TextEnvironmentValues()
+    let first = cache.builder(for: AttributedString("Hello"), environment: environment)
+    let second = cache.builder(for: AttributedString("Hello"), environment: environment)
+    #expect(first === second)
+  }
+
+  @Test func rebuildsWhenTheEnvironmentChanges() {
+    let cache = TextFragment<AttributedString>.BuilderCache()
+    var environment = TextEnvironmentValues()
+    let light = cache.builder(for: AttributedString("Hello"), environment: environment)
+    environment.colorScheme = .dark
+    let dark = cache.builder(for: AttributedString("Hello"), environment: environment)
+    #expect(light !== dark)
+  }
+}


### PR DESCRIPTION
`StructuredText`, `InlineText`, and `TextFragment` seed their content through `onChange(of:initial:)` into `@State`. 

SwiftUI doesn't guarantee appear-family events (`onAppear`, `onChange(initial:)`, `task`) for every materialized view; a row created lazily inside a scroll container while content updates quickly in can miss them entirely. When that happens the view keeps rendering its empty initial state: `body` runs with the right markup, layout happens, but nothing is drawn and nothing reaches accessibility. We encountered when parsing streaming MD data updating frequently from LLMs.

The PR purposes to replace the event-driven seeding with a small memoizing cache held in `@State`: content is derived directly in `body` and parsed once per distinct markup value. Should not change any rendering behavior, if anything, first render now shows content one pass earlier, since it no longer waits for the initial `onChange` round trip. Attachment resolution still runs through `task(id:)` as before.

Two follow-ups from review, both about the caches reusing a result they should not:

- A parser with the same markup but a different configuration (base URL, options, syntax extensions) got the previous parse. `MarkupParser` now has a `cacheKey` (defaulting to the parser's type) that `AttributedStringMarkdownParser` fills from its settings, and `MarkupParseCache` compares it alongside the markup.
- A `TextBuilder` was kept across environment changes, so a colour scheme or dynamic type change only showed once something changed size. `BuilderCache` now compares the `TextEnvironmentValues` too.

Both come with tests.
