### PR TITLE
Fix stale content display when markup changes in StructuredText and InlineText

### DIFF
--- a/Sources/Textual/Internal/Attachment/WithAttachments.swift
+++ b/Sources/Textual/Internal/Attachment/WithAttachments.swift
@@ -53,6 +53,8 @@ extension WithAttachments {
       emojiAttachmentLoader: any AttachmentLoader,
       environment: ColorEnvironmentValues
     ) async {
+      resolvedAttributedString = nil
+
       guard attributedString.containsValues(for: [\.imageURL, \.textual.emojiURL]) else {
         return
       }
@@ -92,6 +94,11 @@ extension WithAttachments {
           ranges.append(range)
         }
       }
+
+      // Cancelling this task (SwiftUI restarts `.task(id:)` when the string changes) doesn't
+      // interrupt the task group's suspended children, so a cancelled task still reaches this
+      // point with stale results. Discard them instead of overwriting the newer string.
+      guard !Task.isCancelled else { return }
 
       resolveAttachmentsFinished(
         attributedString: attributedString,

--- a/Tests/TextualTests/Internal/Attachment/WithAttachmentsTests.swift
+++ b/Tests/TextualTests/Internal/Attachment/WithAttachmentsTests.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+import Testing
+
+@testable import Textual
+
+struct WithAttachmentsTests {
+  private static let attachmentImage = Textual.Image(
+    data: Data(
+      base64Encoded:
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    )!
+  )!
+
+  private static func makeAttachment(text: String) -> ImageAttachment {
+    ImageAttachment(image: attachmentImage, text: text)
+  }
+
+  /// Suspends `attachment(for:...)` until `open()` is called, ignoring cancellation like a
+  /// network request that is already in flight.
+  private struct GatedLoader: AttachmentLoader {
+    let gate: Gate
+
+    func attachment(
+      for _: URL,
+      text: String,
+      environment _: ColorEnvironmentValues
+    ) async throws -> ImageAttachment {
+      await gate.wait()
+      return makeAttachment(text: text)
+    }
+  }
+
+  private struct ImmediateLoader: AttachmentLoader {
+    func attachment(
+      for _: URL,
+      text: String,
+      environment _: ColorEnvironmentValues
+    ) async throws -> ImageAttachment {
+      makeAttachment(text: text)
+    }
+  }
+
+  private actor Gate {
+    private var opened = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    var hasWaiters: Bool {
+      !continuations.isEmpty
+    }
+
+    func wait() async {
+      if opened { return }
+      await withCheckedContinuation { continuation in
+        continuations.append(continuation)
+      }
+    }
+
+    func open() {
+      opened = true
+      continuations.forEach { $0.resume() }
+      continuations.removeAll()
+    }
+  }
+
+  private func imageURLString(_ text: String, url: URL) -> AttributedString {
+    var attributedString = AttributedString(text)
+    attributedString.imageURL = url
+    return attributedString
+  }
+
+  @Test("Resolving a string without attachment URLs clears stale resolved attachments")
+  @MainActor func clearsResolvedAttachmentsWhenStringHasNoAttachmentURLs() async {
+    let model = WithAttachments<EmptyView>.Model()
+    let environment = ColorEnvironmentValues(colorScheme: .light, colorSchemeContrast: .standard)
+    let withImageURL = imageURLString(
+      "image", url: URL(string: "https://example.com/image.png")!
+
+    )
+
+    await model.resolveAttachments(
+      in: withImageURL,
+      imageAttachmentLoader: ImmediateLoader(),
+      emojiAttachmentLoader: ImmediateLoader(),
+      environment: environment
+    )
+    #expect(model.resolvedAttributedString?.containsValues(for: [\.textual.attachment]) == true)
+
+    await model.resolveAttachments(
+      in: AttributedString("plain"),
+      imageAttachmentLoader: ImmediateLoader(),
+      emojiAttachmentLoader: ImmediateLoader(),
+      environment: environment
+    )
+    #expect(model.resolvedAttributedString == nil)
+  }
+
+  @Test("A cancelled resolution discards its stale results")
+  @MainActor func cancelledResolutionDiscardsStaleResults() async throws {
+    let model = WithAttachments<EmptyView>.Model()
+    let gate = Gate()
+    let environment = ColorEnvironmentValues(colorScheme: .light, colorSchemeContrast: .standard)
+    let staleString = imageURLString(
+      "stale", url: URL(string: "https://example.com/stale.png")!
+    )
+    let freshString = imageURLString(
+      "fresh", url: URL(string: "https://example.com/fresh.png")!
+    )
+
+    let staleTask = Task {
+      await model.resolveAttachments(
+        in: staleString,
+        imageAttachmentLoader: GatedLoader(gate: gate),
+        emojiAttachmentLoader: ImmediateLoader(),
+        environment: environment
+      )
+    }
+
+    while await !gate.hasWaiters {
+      try await Task.sleep(nanoseconds: 1_000_000)
+    }
+
+    staleTask.cancel()
+
+    await model.resolveAttachments(
+      in: freshString,
+      imageAttachmentLoader: ImmediateLoader(),
+      emojiAttachmentLoader: ImmediateLoader(),
+      environment: environment
+    )
+    #expect(model.resolvedAttributedString.map { String($0.characters) } == "fresh")
+
+    await gate.open()
+    await staleTask.value
+    #expect(model.resolvedAttributedString.map { String($0.characters) } == "fresh")
+  }
+}


### PR DESCRIPTION
## Summary

`StructuredText` and `InlineText` kept displaying the previous content forever when their
markup changed from content containing image/emoji URLs to content without any. This PR
resets the resolved-attachments cache whenever a new string starts resolving, and discards
results from superseded (cancelled) resolution tasks.

## Impact

- No API changes; `WithAttachments.Model` is internal.
- Affects any live `StructuredText` / `InlineText` whose markup changes after attachments
  were resolved:
  - Switching to content without attachment URLs now updates the display (previously it
    stayed stuck on the old content).
  - Switching between two attachment-bearing strings now shows the new text immediately
    while its attachments load, instead of showing the old resolved content until loading
    finishes.
  - A cancelled resolution can no longer overwrite the result of a newer one.

## Validation

Two new tests in `Tests/TextualTests/Internal/Attachment/WithAttachmentsTests.swift`:

- "Resolving a string without attachment URLs clears stale resolved attachments" —
  resolves a string with an `imageURL`, then resolves a plain string and asserts the cache
  is cleared.
- "A cancelled resolution discards its stale results" — uses a gate-controlled loader that
  ignores cancellation (like a network request already in flight): the stale task is
  cancelled, a fresh string resolves and is stored, then the stale task is released and
  must not overwrite it.

Both tests fail on the pre-fix code and pass with the fix. Full filtered run:
`swift test --filter WithAttachmentsTests`.

## Detail

`WithAttachments.body` renders `model.resolvedAttributedString ?? attributedString`, and
the `@State` model survives markup changes because the view identity is stable. The cache
had two problems:

**Stale cache on the short-circuit path.** `resolveAttachments` returned early via
`containsValues(for: [\.imageURL, \.textual.emojiURL])` without touching the cache, so
after switching to content without attachment URLs nothing invalidated
`resolvedAttributedString` and the body kept hitting the old value — no state change meant
no re-render, ever. Setting `resolvedAttributedString = nil` up front makes the body fall
back to the incoming string right away. This also removes the transient window during
attachment-to-attachment switches where the old resolved content stayed visible until the
new attachments arrived.

**Stale write from a cancelled task.** SwiftUI restarts `.task(id:)` when the string
changes, which cancels the old task — but cancellation is cooperative: it does not
interrupt the task group's already-suspended children, so an old resolution could still
walk into `resolveAttachmentsFinished` after a newer task had already reset the cache,
re-introducing stale content as a race. The `guard !Task.isCancelled` at the write
boundary discards those superseded results.
